### PR TITLE
fix: Adds License name in the output

### DIFF
--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -9,6 +9,19 @@ pub struct LicenseInfo {
     pub is_restrictive: bool,
 }
 
+impl LicenseInfo {
+    pub fn get_license(&self) -> String {
+        match &self.license {
+            Some(license_name) => {
+                String::from(license_name)
+            }
+            None => {
+                String::from("No License")
+            }
+        }
+    }
+}
+
 pub fn analyze_licenses(packages: Vec<Package>) -> Vec<LicenseInfo> {
     packages
         .into_iter()

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -9,10 +9,10 @@ pub fn generate_report(data: Vec<LicenseInfo>, json: bool, verbose: bool) {
             if verbose {
                 println!(
                     "Name: {}, Version: {}, License: {:?}, Restrictive: {}",
-                    info.name, info.version, info.license, info.is_restrictive
+                    info.name, info.version, info.get_license(), info.is_restrictive
                 );
             } else {
-                println!("{}@{} - {:?}", info.name, info.version, info.license);
+                println!("{}@{} - {:?}", info.name, info.version, info.get_license());
             }
         }
     }


### PR DESCRIPTION
Adding the get_license function which helps to parse Some and get the name of the license instead of Some.