### PR TITLE
add choosealincese live data for license check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "feluda"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -462,6 +462,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "serde_yaml",
  "spinners",
  "tempfile",
  "unicode-width 0.2.0",
@@ -874,6 +875,16 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "indoc"
@@ -1309,7 +1320,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1611,6 +1622,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2076,6 +2100,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feluda"
-version = "1.2.3"
+version = "1.3.0"
 edition = "2021"
 description = "A CLI tool to check dependency licenses."
 readme = "README.md"
@@ -27,6 +27,7 @@ color-eyre = "0.6.3"
 ratatui = "0.29.0"
 unicode-width = "0.2.0"
 spinners = "4.1.1"
+serde_yaml = "0.9.34"
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ feluda --gui
 
 Checkout [contributing guidelines](./CONTRIBUTING.md) if you are looking to contribute to this project.
 
+> Currently, using [choosealicense](https://choosealicense.com/) license directory for source of truth.
+
 ---
 
 ## License
 
-Feluda is licensed under the [MIT License with Commons Clause](./LICENSE).
+Feluda is licensed under the [MIT License](./LICENSE).
 
 _Happy coding with Feluda!_ 🚀


### PR DESCRIPTION
Instead of using string matching with limited data, using data from [choosealicense](https://github.com/github/choosealicense.com) to match.

The function can be improved later for performance and other keyword searches.

fixes issue #6 