### PR TITLE
Optimizing the go-parser

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "mockall",
  "ratatui",
  "rayon",
+ "regex",
  "reqwest",
  "scraper",
  "serde",
@@ -1572,6 +1573,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rayon = "1.10.0"
 figment = { version = "0.10", features = ["toml", "env"] }
 ignore = "0.4.23"
 toml = "0.8"
+regex = "1.11.1"
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 
 /// Main configuration structure for Feluda
 #[derive(Debug, Deserialize, Serialize)]
+#[derive(Default)]
 pub struct FeludaConfig {
     #[serde(default)]
     pub licenses: LicenseConfig,
@@ -68,13 +69,6 @@ impl Default for LicenseConfig {
     }
 }
 
-impl Default for FeludaConfig {
-    fn default() -> Self {
-        Self {
-            licenses: LicenseConfig::default(),
-        }
-    }
-}
 
 /// Returns the default list of restrictive licenses
 fn default_restrictive_licenses() -> Vec<String> {

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -85,14 +85,8 @@ struct PackageJson {
 impl PackageJson {
     fn get_all_dependencies(self) -> HashMap<String, String> {
         let mut all_dependencies: HashMap<String, String> = HashMap::new();
-        match self.dev_dependencies {
-            Some(deps) => all_dependencies.extend(deps),
-            None => (),
-        };
-        match self.dependencies {
-            Some(deps) => all_dependencies.extend(deps),
-            None => (),
-        };
+        if let Some(deps) = self.dev_dependencies { all_dependencies.extend(deps) };
+        if let Some(deps) = self.dependencies { all_dependencies.extend(deps) };
         all_dependencies
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -53,7 +53,7 @@ fn find_project_roots(root_path: impl AsRef<Path>) -> Vec<ProjectRoot> {
     let mut project_roots = Vec::new();
 
     for entry in Walk::new(root_path).flatten() {
-        if !entry.file_type().map_or(false, |ft| ft.is_file()) {
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
             continue;
         }
 
@@ -217,13 +217,20 @@ mod tests {
     github.com/aws/aws-sdk-go-v2/credentials v1.13.43
     github.com/aws/aws-sdk-go-v2/service/route53 v1.30.2
     github.com/cespare/cp v0.1.0
-    github.com/cloudflare/cloudflare-go v0.79.0
-    github.com/cockroachdb/pebble v1.1.2
-    github.com/consensys/gnark-crypto v0.14.0
-    github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a
+    github.com/cloudflare/cloudflare-go v0.79.0 //indirect
+    github.com/cockroachdb/pebble v1.1.2 //indirect
     github.com/crate-crypto/go-kzg-4844 v1.1.0
-    github.com/davecgh/go-spew v1.1.1
-)"#;
+    github.com/davecgh/go-spew v1.1.1 # Another comment
+    github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a
+    github.com/consensys/gnark-crypto v0.14.0
+    github.com/go-sourcemap/sourcemap v2.1.3+incompatible // Check the version
+)
+
+require example.com/theirmodule v1.3.4
+
+require (github.com/some/module v1.0.0)
+require (github.com/another/module v2.3.4)
+require (github.com/mixed-case/Module v3.5.7-beta)"#;
         fs::write(&go_mod_path, dependencies).unwrap();
 
         let result = parse_dependencies(&ProjectRoot {
@@ -231,7 +238,7 @@ mod tests {
             project_type: Language::Go("go.mod"),
         });
         let parsed = get_go_dependencies(dependencies.to_string());
-        assert!(parsed.len() == 14);
+        assert!(parsed.len() == 19);
         assert!(result.len() == parsed.len());
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -157,6 +157,8 @@ fn parse_dependencies(root: &ProjectRoot) -> Vec<LicenseInfo> {
 // Tests
 #[cfg(test)]
 mod tests {
+    use crate::licenses::get_go_dependencies;
+
     use super::*;
     use std::fs;
 
@@ -206,13 +208,31 @@ mod tests {
     fn test_parse_dependencies_go() {
         let temp_dir = tempfile::tempdir().unwrap();
         let go_mod_path = temp_dir.path().join("go.mod");
-        fs::write(&go_mod_path, "").unwrap();
+        let dependencies = r#"require (
+    github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.2.0
+    github.com/Microsoft/go-winio v0.6.2
+    github.com/VictoriaMetrics/fastcache v1.12.2
+    github.com/aws/aws-sdk-go-v2 v1.21.2
+    github.com/aws/aws-sdk-go-v2/config v1.18.45
+    github.com/aws/aws-sdk-go-v2/credentials v1.13.43
+    github.com/aws/aws-sdk-go-v2/service/route53 v1.30.2
+    github.com/cespare/cp v0.1.0
+    github.com/cloudflare/cloudflare-go v0.79.0
+    github.com/cockroachdb/pebble v1.1.2
+    github.com/consensys/gnark-crypto v0.14.0
+    github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a
+    github.com/crate-crypto/go-kzg-4844 v1.1.0
+    github.com/davecgh/go-spew v1.1.1
+)"#;
+        fs::write(&go_mod_path, dependencies).unwrap();
 
         let result = parse_dependencies(&ProjectRoot {
             path: temp_dir.path().to_path_buf(),
             project_type: Language::Go("go.mod"),
         });
-        assert!(result.is_empty());
+        let parsed = get_go_dependencies(dependencies.to_string());
+        assert!(parsed.len() == 14);
+        assert!(result.len() == parsed.len());
     }
 
     #[test]


### PR DESCRIPTION
* Improves the time to parse go projects:

```
from:
cargo run -- -p ../go-ethereum  9.45s user 1.13s system 9% cpu 1:52.8 total
to:
cargo run -- -p ../go-ethereum  4.01s user 0.46s system 29% cpu 15.126 total
```

* Adds clippy warning for better linting