### PR TITLE
Add yaml output

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,27 @@ Sample Output for a sample cargo.toml file containing `serde` and `tokio` depend
 ]
 ```
 
+- YAML: Use the `--yaml` flag for YAML output.
+
+```sh
+feluda --yaml
+```
+
+Sample Output for a sample cargo.toml file containing `serde` and `tokio` dependencies:
+
+```yaml
+- name: serde
+  version: 1.0.151
+  license: MIT
+  is_restrictive: false
+  compatibility: Compatible
+- name: tokio
+  version: 1.0.2
+  license: MIT
+  is_restrictive: false
+  compatibility: Compatible
+```
+
 ### Verbose Mode
 
 For detailed information about each dependency:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,13 @@ pub struct Cli {
     /// This is useful for CI/CD pipelines.
     pub json: bool,
 
+    /// Output in YAML format
+    #[arg(long, short, group = "output")]
+    /// This will override the default output format
+    /// and will not show the TUI table.
+    /// This is useful for CI/CD pipelines.
+    pub yaml: bool,
+
     /// Enable verbose output
     #[arg(long)]
     pub verbose: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,7 @@ fn run() -> FeludaResult<()> {
         let (has_restrictive, has_incompatible) = generate_report(
             analyzed_data,
             args.json,
+            args.yaml,
             args.verbose,
             args.strict,
             args.ci_format,

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -75,9 +75,12 @@ impl TableFormatter {
     }
 }
 
+// Need to refactor this later.
+#[allow(clippy::too_many_arguments)]
 pub fn generate_report(
     data: Vec<LicenseInfo>,
     json: bool,
+    yaml: bool,
     verbose: bool,
     strict: bool,
     ci_format: Option<CiFormat>,
@@ -163,6 +166,16 @@ pub fn generate_report(
             Err(err) => {
                 log_error("Failed to serialize data to JSON", &err);
                 println!("Error: Failed to generate JSON output");
+            }
+        }
+    } else if yaml {
+        // YAML output
+        log(LogLevel::Info, "Generating YAML output");
+        match serde_yaml::to_string(&filtered_data) {
+            Ok(yaml_output) => println!("{}", yaml_output),
+            Err(err) => {
+                log_error("Failed to serialize data to YAML", &err);
+                println!("Error: Failed to generate YAML output");
             }
         }
     } else if verbose {
@@ -883,7 +896,7 @@ mod tests {
     #[test]
     fn test_generate_report_empty_data() {
         let data = vec![];
-        let result = generate_report(data, false, false, false, None, None, None);
+        let result = generate_report(data, false, false, false, false, None, None, None);
         assert_eq!(result, (false, false)); // No restrictive or incompatible licenses
     }
 
@@ -892,6 +905,7 @@ mod tests {
         let data = get_test_data();
         let result = generate_report(
             data,
+            false,
             false,
             false,
             false,
@@ -907,6 +921,7 @@ mod tests {
         let data = get_test_data();
         let result = generate_report(
             data,
+            false,
             false,
             false,
             true,
@@ -925,6 +940,23 @@ mod tests {
             true,
             false,
             false,
+            false,
+            None,
+            None,
+            Some("MIT".to_string()),
+        );
+        assert_eq!(result, (true, true));
+    }
+
+    #[test]
+    fn test_generate_report_yaml() {
+        let data = get_test_data();
+        let result = generate_report(
+            data,
+            false,
+            true,
+            false,
+            false,
             None,
             None,
             Some("MIT".to_string()),
@@ -938,6 +970,7 @@ mod tests {
         let result = generate_report(
             data,
             false,
+            false,
             true,
             false,
             None,
@@ -950,7 +983,7 @@ mod tests {
     #[test]
     fn test_generate_report_no_project_license() {
         let data = get_test_data_with_unknown_compatibility();
-        let result = generate_report(data, false, false, false, None, None, None);
+        let result = generate_report(data, false, false, false, false, None, None, None);
         assert_eq!(result, (true, false)); // Has restrictive but no incompatible since no project license
     }
 
@@ -962,6 +995,7 @@ mod tests {
 
         let result = generate_report(
             data,
+            false,
             false,
             false,
             false,
@@ -995,6 +1029,7 @@ mod tests {
             false,
             false,
             false,
+            false,
             Some(CiFormat::Jenkins),
             Some(output_path.to_str().unwrap().to_string()),
             Some("MIT".to_string()),
@@ -1023,6 +1058,7 @@ mod tests {
 
         let result = generate_report(
             data,
+            false,
             false,
             false,
             false,


### PR DESCRIPTION
This PR adds YAML output support as requested in issue #65.

Changes include:
- New `--yaml` command line flag for YAML format output
- Added `yaml` parameter to `generate_report` function
- Updated all existing calls to `generate_report` to accommodate the new parameter
- Added `test_generate_report_yaml` test
- Documentation updates in README.md

These changes pass all existing tests.
