### PR TITLE
refactored generate_report function to match the new structure 

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,82 @@ feluda --gui
 ![ss-gui](https://github.com/user-attachments/assets/44d46755-b186-4326-a3fb-548da31f3acd)
 
 
+### Programmatic Usage
+
+Feluda can be used as a library in Rust projects. The main entry point for generating reports is the generate_report function in the reporter module, which takes a Vec<LicenseInfo> and a ReportConfig struct.
+
+Example 
+```example
+use feluda::licenses::{LicenseCompatibility, LicenseInfo};
+use feluda::reporter::{generate_report, ReportConfig};
+use feluda::cli::CiFormat;
+
+fn main() {
+    let data = vec![
+        LicenseInfo {
+            name: "serde".to_string(),
+            version: "1.0.151".to_string(),
+            license: Some("MIT".to_string()),
+            is_restrictive: false,
+            compatibility: LicenseCompatibility::Compatible,
+        },
+        LicenseInfo {
+            name: "tokio".to_string(),
+            version: "1.0.2".to_string(),
+            license: Some("MIT".to_string()),
+            is_restrictive: false,
+            compatibility: LicenseCompatibility::Compatible,
+        },
+    ];
+
+    let config = ReportConfig::new(
+        false,                    // json
+        false,                    // yaml
+        true,                     // verbose
+        false,                    // strict
+        None,                     // ci_format
+        Some("report.txt".to_string()), // output_file
+        Some("MIT".to_string()), // project_license
+    );
+
+    let (has_restrictive, has_incompatible) = generate_report(data, config);
+    println!("Has restrictive licenses: {}", has_restrictive);
+    println!("Has incompatible licenses: {}", has_incompatible);
+}
+```
+
+### ReportConfig Struct
+
+
+The ReportConfig struct configures the generate_report function:
+
+```struct
+pub struct ReportConfig {
+    pub json: bool,                    
+    pub yaml: bool,                   
+    pub verbose: bool,                 
+    pub strict: bool,                 
+    pub ci_format: Option<CiFormat>,  
+    pub output_file: Option<String>,   
+    pub project_license: Option<String>,
+}
+```
+
+## Create a ReportConfig using the new method:
+
+```new_struct
+let config = ReportConfig::new(
+    false,
+    false,
+    true,
+    false,
+    None,
+    None,
+    Some("MIT".to_string())
+);
+```
+
+
 ## CI/CD Integration
 
 Feluda provides several options for CI integration:

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use cli::{print_version_info, Cli};
 use debug::{log, log_debug, set_debug_mode, FeludaError, FeludaResult, LogLevel};
 use licenses::{detect_project_license, is_license_compatible, LicenseCompatibility};
 use parser::parse_root;
-use reporter::generate_report;
+use reporter::{generate_report, ReportConfig};
 use std::env;
 use std::process;
 use table::App;
@@ -207,17 +207,19 @@ fn run() -> FeludaResult<()> {
     } else {
         log(LogLevel::Info, "Generating dependency report");
 
-        // Generate a report based on the analyzed data
-        let (has_restrictive, has_incompatible) = generate_report(
-            analyzed_data,
+        // Create ReportConfig from CLI arguments
+        let config = ReportConfig::new(
             args.json,
             args.yaml,
             args.verbose,
             args.strict,
             args.ci_format,
-            args.output_file.clone(),
+            args.output_file,
             project_license,
         );
+
+        // Generate a report based on the analyzed data
+        let (has_restrictive, has_incompatible) = generate_report(analyzed_data, config);
 
         log(
             LogLevel::Info,


### PR DESCRIPTION
# Refactor `generate_report` to Use `ReportConfig` Struct

## Description

This pull request refactors the `generate_report` function in the `reporter` module to improve maintainability and address Clippy's `too_many_arguments` warning. The function's 8 arguments are consolidated into a single `ReportConfig` struct, reducing complexity and enhancing code clarity. All call sites, tests, and documentation have been updated to reflect this change.
Fixes #82 

## Changes

### 1. `reporter.rs`
- Introduced a new `ReportConfig` struct to encapsulate the configuration options (`json`, `yaml`, `verbose`, `strict`, `ci_format`, `output_file`, `project_license`).
- Updated the `generate_report` function signature to `pub fn generate_report(data: Vec<LicenseInfo>, config: ReportConfig) -> (bool, bool)`.
- Modified all internal logic to use `config.<field>` instead of individual arguments.
- Updated all tests to use `ReportConfig::new`, ensuring no change in behavior.
- Removed the `#[allow(clippy::too_many_arguments)]` attribute, as the function now has only 2 arguments.

### 2. `main.rs`
- Added `ReportConfig` to the imports from the `reporter` module.
- Updated the `generate_report` call site to create a `ReportConfig` instance using `ReportConfig::new` with CLI arguments.
- Preserved all other logic (dependency parsing, TUI mode, exit codes) unchanged.

### 3. `README.md`
- Documented the `ReportConfig` struct, including its fields and usage with `ReportConfig::new`.

# All test passes
![image](https://github.com/user-attachments/assets/38fc9793-2cd0-43a2-b851-f81e1e0811a0)

