### PR TITLE
fix broken output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -230,6 +230,9 @@ impl LoadingIndicator {
         let spinner_frames = self.spinner_frames.clone();
         let progress = self.progress.clone();
 
+        // Clear the current line and move to beginning
+        print!("\x1B[2K\r");
+
         // Print initial message with spinner
         print!("{} {} ", spinner_frames[0].cyan(), message);
         io::stdout().flush().unwrap();
@@ -240,7 +243,7 @@ impl LoadingIndicator {
                 frame_idx = (frame_idx + 1) % spinner_frames.len();
 
                 // Clear the current line and move to beginning
-                print!("\r");
+                print!("\x1B[2K\r");
 
                 // Print spinner and message
                 let spinner_char = spinner_frames[frame_idx];
@@ -256,7 +259,7 @@ impl LoadingIndicator {
             }
 
             // Clear line and print completion message
-            print!("\r");
+            print!("\x1B[2K\r");
             print!("{} {} ", "✓".green().bold(), message);
             if let Some(ref progress_text) = *progress.lock().unwrap() {
                 print!("({})", progress_text);
@@ -295,10 +298,10 @@ impl LoadingIndicator {
 /// let result = with_spinner("Processing data", |indicator| {
 ///     // Initial work
 ///     let data = prepare_data();
-///     
+///
 ///     // Update progress
 ///     indicator.update_progress(&format!("processed {} items", data.len()));
-///     
+///
 ///     // Continue processing
 ///     process_data(data)
 /// });


### PR DESCRIPTION
this pull request fixes issue #64. The problem was that the `start` function of the `Loading Indicator` structure used `"\r"` to clear a line and move the carriage to its beginning, but it only moves the carriage to the beginning of the line, not clears it, so an additional ANSI sequence was added to clear the current line. Also, line cleanup has been added when outputting the initial message, since the `parse_dependencies` function creates one `cli::with_spinner` and then `fetch_licenses_from_github` is called in it, which also creates `cli::with_spinner`, and since they are output on the same terminal line, the line must first be cleared.

The same method of clearing the terminal line is used in https://github.com/crossterm-rs/crossterm.

In lines 301 and 304, the formatter removed the extra spaces after the comment characters.

Fixed output example:
![image](https://github.com/user-attachments/assets/2175fb00-1e43-4ae4-b568-7334f0fa40b9)
