### PR TITLE
feat:github actions to test and update the feluda badge

### DIFF
--- a/.github/workflows/feluda.yml
+++ b/.github/workflows/feluda.yml
@@ -1,3 +1,4 @@
+# .github/workflows/license-check.yml
 name: License Check
 
 on:
@@ -21,4 +22,43 @@ jobs:
         run: cargo install feluda
 
       - name: Check licenses
-        run: feluda --ci-format github --fail-on-restrictive
+        id: feluda
+        shell: bash
+        run: |
+          set +e
+          FELUDA_LOG=$(feluda --ci-format github --fail-on-restrictive 2>&1)
+          FELUDA_EXIT=$?
+          echo "feluda_log<<EOF" >> $GITHUB_OUTPUT
+          echo "$FELUDA_LOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          if [[ $FELUDA_EXIT -eq 0 ]]; then
+            echo "license_check=success" >> $GITHUB_OUTPUT
+          else
+            echo "license_check=failure" >> $GITHUB_OUTPUT
+          fi
+        continue-on-error: true
+
+      - name: Update Feluda badge
+        if: always()
+        run: |
+          if [[ "${{ steps.feluda.outputs.license_check }}" == "success" ]]; then
+            COLOR="brightgreen"
+            echo "License check passed"
+          else
+            COLOR="red"
+            echo "License check failed"
+          fi
+
+          sed -i -E "s#https://img\.shields\.io/badge/Scanned%20with-Feluda-[^)]+#https://img.shields.io/badge/Scanned%20with-Feluda-${COLOR}#g" README.md
+
+      - name: Commit badge update
+        if: always()
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: README.md
+          message: "docs: update Feluda scan badge"
+
+      - name: Fail if license check failed
+        if: steps.feluda.outputs.license_check == 'failure'
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Feluda
 
 [![Crates.io Version](https://img.shields.io/crates/v/feluda)
-](https://crates.io/crates/feluda) [![Crates.io Downloads](https://img.shields.io/crates/d/feluda)](https://crates.io/crates/feluda) [![Crates.io Downloads (latest version)](https://img.shields.io/crates/dv/feluda)](https://crates.io/crates/feluda) [![Open Source](https://img.shields.io/badge/open-source-brightgreen)](https://github.com/anistark/feluda) [![Contributors](https://img.shields.io/github/contributors/anistark/feluda)](https://github.com/anistark/feluda/graphs/contributors) ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
+](https://crates.io/crates/feluda) [![Crates.io Downloads](https://img.shields.io/crates/d/feluda)](https://crates.io/crates/feluda) [![Crates.io Downloads (latest version)](https://img.shields.io/crates/dv/feluda)](https://crates.io/crates/feluda) [![Open Source](https://img.shields.io/badge/open-source-brightgreen)](https://github.com/anistark/feluda) [![Contributors](https://img.shields.io/github/contributors/anistark/feluda)](https://github.com/anistark/feluda/graphs/contributors) ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg) [![Scanned with Feluda](https://img.shields.io/badge/Scanned%20with-Feluda-red)](https://github.com/anistark/feluda)
 
 🔎 **Feluda** is a Rust-based command-line tool that analyzes the dependencies of a project, notes down their licenses, and flags any permissions that restrict personal or commercial usage or are incompatible with your project's license.
 


### PR DESCRIPTION
PR is opened against https://github.com/anistark/feluda/issues/62, changes are:-

- Added a “Scanned with Feluda” badge in the README to be updated by the workflow

- Modified the GitHub Actions workflow to install Feluda, perform the license check, update the badge color in README based on success or failure and commits.

