### PR TITLE
.github: Add multi-arch and draft releases suport

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -17,6 +17,13 @@ jobs:
     name: Build .rpm package
     runs-on: ubuntu-latest
     if: github.repository_owner == 'anistark'
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            arch: x86_64
+          - target: aarch64-unknown-linux-gnu
+            arch: aarch64
     steps:
       - uses: actions/checkout@v4
 
@@ -26,6 +33,10 @@ jobs:
       - name: Install cargo-rpm
         run: cargo install cargo-rpm
 
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+
       - name: Build .rpm package
         run: |
           # Initialize RPM configuration if .rpm directory doesn't exist
@@ -33,14 +44,17 @@ jobs:
             echo "Initializing RPM configuration..."
             cargo rpm init
           fi
-          cargo rpm build --target x86_64-unknown-linux-gnu
-          RPM_FILE=$(find target/x86_64-unknown-linux-gnu/release/rpmbuild/RPMS -name "*.rpm")
+          cargo rpm build --target ${{ matrix.target }}
+          RPM_FILE=$(find target/${{ matrix.target }}/release/rpmbuild/RPMS -name "*.rpm")
           VERSION=${GITHUB_REF#refs/tags/}
-          cp "$RPM_FILE" "feluda-${VERSION}-x86_64.rpm"
+          cp "$RPM_FILE" "feluda-${VERSION}-${{ matrix.arch }}.rpm"
 
-      - name: Upload .rpm to release
+      - name: Upload .rpm artifacts
         uses: softprops/action-gh-release@v1
         with:
           files: "feluda-*.rpm"
+          draft: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add support for adding multiple arches, added aarch64. Also, include logic to not release hyphened releases, rather keep the releases in draft.