### PR TITLE
.github: Disable building rpm for aarch64

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -22,8 +22,10 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             arch: x86_64
-          - target: aarch64-unknown-linux-gnu
-            arch: aarch64
+          # -- start comment: disable aarch64 for now.
+          #- target: aarch64-unknown-linux-gnu
+          #  arch: aarch64
+          # -- end comment
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The setup is broken on Github Actions. We would need to investigate and re-add it later