### PR TITLE
fix: add missing env var cleanup to prevent test isolation issues in parallel execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "spinners",
  "temp-env",
  "tempfile",
@@ -674,6 +675,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +704,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -713,6 +740,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -2098,6 +2126,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2154,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "selectors"
@@ -2230,6 +2273,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tempfile = "3.19.1"
 mockall = "0.13.1"
 http = "1.3.1"
 temp-env = "0.3.1"
+serial_test = "3.2.0"
 
 [features]
 default = []

--- a/src/sbom/spdx.rs
+++ b/src/sbom/spdx.rs
@@ -890,8 +890,10 @@ pub fn generate_spdx_output(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn test_convert_to_spdx_license_expression() {
         // Ensure environment variable is not set
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
@@ -999,6 +1001,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_license_expression_edge_cases() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
 
@@ -1108,6 +1111,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_complex_package_names() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
         // Test the specific lodash.castarray case
@@ -1145,6 +1149,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_extreme_edge_case_packages() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
 
@@ -1213,6 +1218,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_micromark_util_symbol_case() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
         // Test the specific case from the error message
@@ -1243,6 +1249,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_license_concluded_vs_declared() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
         // Test normal license handling
@@ -1325,6 +1332,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_ultra_conservative_license_validation() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
 
@@ -1412,6 +1420,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_force_noassertion_mode() {
         // Test normal mode first
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
@@ -1485,6 +1494,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_package_metadata_validation() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
 
@@ -1522,6 +1532,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_download_location_validation() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
 
@@ -1553,6 +1564,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_copyright_validation() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
 
@@ -1576,6 +1588,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_external_ref_validation() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
 
@@ -1608,6 +1621,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_comment_validation() {
         std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
 


### PR DESCRIPTION
fixes #181 