### PR TITLE
feat(docs): add Field Reports timeline to homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target
 .DS_Store
 .vscode
 *.json
+!docs/source/_static/field-reports.json
 *.bak
 docs/build
 docs/_build

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -210,6 +210,21 @@ html:not([data-theme="dark"]) .sd-card.glassmorphic:hover {
     50%      { box-shadow: 0 0 0 9px rgba(16, 185, 129, 0); }
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .field-report-dot,
+    .field-report-item.is-upcoming .field-report-dot {
+        animation: none;
+        transition: none;
+    }
+
+    .field-report-item:hover .field-report-dot {
+        transform: none;
+    }
+
+    .field-report-content {
+        transition: none;
+    }
+}
 .field-report-item:hover .field-report-dot {
     transform: scale(1.2);
 }

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -127,3 +127,230 @@ html:not([data-theme="dark"]) .sd-card.glassmorphic:hover {
     color: var(--sd-color-primary);
     font-weight: 500;
 }
+
+/* Field Reports — vertical timeline */
+.field-reports-timeline {
+    list-style: none;
+    margin: 1.5rem 0 0;
+    padding: 0 !important;
+    padding-inline-start: 0 !important;
+    position: relative;
+}
+
+.field-report-item {
+    display: grid;
+    grid-template-columns: 2.5rem 1fr;
+    gap: 0.75rem;
+    padding: 0 0 1.75rem;
+    margin: 0;
+    list-style: none;
+    position: relative;
+}
+
+.field-report-item:last-child {
+    padding-bottom: 0;
+}
+
+/* Rail column — both the line and the dot share this container's center axis,
+   so they're guaranteed to align horizontally regardless of theme padding. */
+.field-report-rail {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Per-item rail line — extends slightly past the item's bottom so it overlaps
+   into the next item's rail with no sub-pixel gap. */
+.field-report-rail::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: -2rem;
+    left: 50%;
+    width: 2px;
+    transform: translateX(-50%);
+    background: linear-gradient(
+        to bottom,
+        rgba(168, 85, 247, 0.5),
+        rgba(99, 102, 241, 0.4),
+        rgba(168, 85, 247, 0.5)
+    );
+    border-radius: 2px;
+    z-index: 0;
+}
+
+.field-report-item:last-child .field-report-rail::before {
+    bottom: 0;
+}
+
+.field-report-dot {
+    position: relative;
+    z-index: 1;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #a855f7;
+    transition: transform 0.2s ease;
+    animation: field-report-pulse-purple 2.4s ease-in-out infinite;
+}
+
+.field-report-item.is-upcoming .field-report-dot {
+    background: #10b981;
+    animation: field-report-pulse-green 2s ease-in-out infinite;
+}
+
+@keyframes field-report-pulse-purple {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(168, 85, 247, 0.45); }
+    50%      { box-shadow: 0 0 0 7px rgba(168, 85, 247, 0); }
+}
+
+@keyframes field-report-pulse-green {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.55); }
+    50%      { box-shadow: 0 0 0 9px rgba(16, 185, 129, 0); }
+}
+
+.field-report-item:hover .field-report-dot {
+    transform: scale(1.2);
+}
+
+.field-report-content {
+    position: relative;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-radius: 12px;
+    padding: 0.85rem 1rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Stretched link — title's <a> covers the entire card so the whole card is clickable */
+.field-report-item.has-link {
+    cursor: pointer;
+}
+
+.field-report-item.has-link .field-report-title a::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border-radius: inherit;
+}
+
+html[data-theme="dark"] .field-report-content {
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+html:not([data-theme="dark"]) .field-report-content {
+    background: rgba(255, 255, 255, 0.09);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.field-report-item:hover .field-report-content {
+    transform: translateY(-2px);
+}
+
+html[data-theme="dark"] .field-report-item:hover .field-report-content {
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+html:not([data-theme="dark"]) .field-report-item:hover .field-report-content {
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+}
+
+.field-report-item.is-upcoming .field-report-content {
+    border-left: 3px solid var(--sd-color-primary, #6366f1);
+}
+
+.field-report-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+    font-size: 0.8rem;
+    color: var(--sy-c-text-muted, #6b7280);
+    margin-bottom: 0.35rem;
+}
+
+.field-report-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: var(--sy-c-bg-subtle, rgba(127, 127, 127, 0.12));
+    border: 1px solid var(--sy-c-border, rgba(127, 127, 127, 0.2));
+}
+
+.field-report-item.is-upcoming .field-report-chip {
+    background: rgba(99, 102, 241, 0.12);
+    border-color: rgba(99, 102, 241, 0.4);
+    color: var(--sd-color-primary, #6366f1);
+}
+
+.field-report-title {
+    margin: 0 0 0.25rem;
+    font-size: 1.05rem;
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+.field-report-title a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: none;
+}
+
+.field-report-title a:hover {
+    color: var(--sd-color-primary, #6366f1);
+    text-decoration: none;
+    border-bottom: none;
+}
+
+.field-report-byline {
+    margin: 0 0 0.35rem;
+    font-size: 0.85rem;
+    color: var(--sy-c-text-muted, #6b7280);
+}
+
+.field-report-speaker,
+.field-report-venue {
+    transition: color 0.2s ease;
+}
+
+/* On card hover, give speaker and venue distinct accent colors */
+.field-report-item:hover .field-report-speaker {
+    color: #a855f7; /* purple — matches dot */
+}
+
+.field-report-item:hover .field-report-venue {
+    color: #10b981; /* green — matches upcoming dot */
+}
+
+.field-report-desc {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
+}
+
+.field-reports-empty {
+    margin: 1rem 0;
+    padding: 1rem;
+    text-align: center;
+    color: var(--sy-c-text-muted, #6b7280);
+    font-style: italic;
+}
+
+@media (max-width: 480px) {
+    .field-report-item {
+        grid-template-columns: 1.5rem 1fr;
+        gap: 0.5rem;
+    }
+    .field-report-content {
+        padding: 0.7rem 0.85rem;
+    }
+}

--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -9,50 +9,153 @@ document.addEventListener('DOMContentLoaded', function() {
     // Fetch and render contributors
     const contributorsContainer = document.getElementById('contributors-container');
     if (contributorsContainer) {
-        const CACHE_KEY = 'feluda_contributors';
-        const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+        (() => {
+            const CACHE_KEY = 'feluda_contributors';
+            const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
 
-        const renderContributors = (contributors) => {
-            const filtered = contributors.filter(c => !c.login.includes('[bot]') && c.login !== 'dependabot');
-            contributorsContainer.innerHTML = filtered.map(contributor => `
-                <a href="${contributor.html_url}" target="_blank" rel="noopener noreferrer" title="${contributor.login}">
-                    <img src="${contributor.avatar_url}" alt="${contributor.login}" class="contributor-avatar" />
-                </a>
-            `).join('');
+            const renderContributors = (contributors) => {
+                const filtered = contributors.filter(c => !c.login.includes('[bot]') && c.login !== 'dependabot');
+                contributorsContainer.innerHTML = filtered.map(contributor => `
+                    <a href="${contributor.html_url}" target="_blank" rel="noopener noreferrer" title="${contributor.login}">
+                        <img src="${contributor.avatar_url}" alt="${contributor.login}" class="contributor-avatar" />
+                    </a>
+                `).join('');
+            };
+
+            const showFallback = () => {
+                contributorsContainer.innerHTML = '<a href="https://github.com/anistark/feluda/graphs/contributors" target="_blank" rel="noopener noreferrer">View contributors on GitHub</a>';
+            };
+
+            // Check cache first
+            const cached = localStorage.getItem(CACHE_KEY);
+            if (cached) {
+                const { data, timestamp } = JSON.parse(cached);
+                if (Date.now() - timestamp < CACHE_TTL) {
+                    renderContributors(data);
+                    return;
+                }
+            }
+
+            // Fetch from API
+            fetch('https://api.github.com/repos/anistark/feluda/contributors')
+                .then(response => {
+                    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                    return response.json();
+                })
+                .then(contributors => {
+                    localStorage.setItem(CACHE_KEY, JSON.stringify({ data: contributors, timestamp: Date.now() }));
+                    renderContributors(contributors);
+                })
+                .catch(error => {
+                    console.error('Failed to fetch contributors:', error);
+                    // Try to use stale cache if available
+                    if (cached) {
+                        renderContributors(JSON.parse(cached).data);
+                    } else {
+                        showFallback();
+                    }
+                });
+        })();
+    }
+
+    // Fetch and render Field Reports timeline
+    const fieldReportsContainer = document.getElementById('field-reports-container');
+    if (fieldReportsContainer) {
+        const escapeHtml = (str) => String(str ?? '').replace(/[&<>"']/g, (c) => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+
+        const formatDate = (iso) => {
+            const d = new Date(iso);
+            if (isNaN(d)) return iso;
+            return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
         };
 
-        const showFallback = () => {
-            contributorsContainer.innerHTML = '<a href="https://github.com/anistark/feluda/graphs/contributors" target="_blank" rel="noopener noreferrer">View contributors on GitHub</a>';
+        const typeMeta = {
+            video:     { label: 'Video',          icon: '▶' },
+            slides:    { label: 'Slides',         icon: '📄' },
+            upcoming:  { label: 'Upcoming',       icon: '🔮' },
+            article:   { label: 'Article',        icon: '✍' },
+            podcast:   { label: 'Podcast',        icon: '🎙' },
+            talk:      { label: 'Talk',           icon: '🎤' },
+            lightning: { label: 'Lightning Talk', icon: '⚡' }
         };
 
-        // Check cache first
-        const cached = localStorage.getItem(CACHE_KEY);
-        if (cached) {
-            const { data, timestamp } = JSON.parse(cached);
-            if (Date.now() - timestamp < CACHE_TTL) {
-                renderContributors(data);
+        const renderReports = (reports) => {
+            if (!Array.isArray(reports) || reports.length === 0) {
+                fieldReportsContainer.innerHTML = '<p class="field-reports-empty">No field reports yet — check back soon.</p>';
                 return;
+            }
+
+            const sorted = [...reports].sort((a, b) => new Date(b.date) - new Date(a.date));
+
+            const items = sorted.map((r) => {
+                const type = (r.type || '').toLowerCase();
+                const meta = typeMeta[type] || { label: type || 'Talk', icon: '•' };
+                const isUpcoming = type === 'upcoming' || new Date(r.date) > new Date();
+                const url = r.url ? escapeHtml(r.url) : '';
+                const titleHtml = url
+                    ? `<a href="${url}" target="_blank" rel="noopener noreferrer">${escapeHtml(r.title)}</a>`
+                    : escapeHtml(r.title);
+
+                const bylineParts = [];
+                if (r.speaker) bylineParts.push(`<span class="field-report-speaker">${escapeHtml(r.speaker)}</span>`);
+                if (r.venue) bylineParts.push(`<span class="field-report-venue">${escapeHtml(r.venue)}</span>`);
+                const bylineHtml = bylineParts.join('<span class="field-report-byline-sep" aria-hidden="true"> · </span>');
+
+                const itemClasses = [
+                    'field-report-item',
+                    isUpcoming ? 'is-upcoming' : '',
+                    url ? 'has-link' : ''
+                ].filter(Boolean).join(' ');
+
+                return `
+                    <li class="${itemClasses}" data-type="${escapeHtml(type)}">
+                        <div class="field-report-rail">
+                            <span class="field-report-dot" aria-hidden="true"></span>
+                        </div>
+                        <div class="field-report-content">
+                            <div class="field-report-meta">
+                                <time datetime="${escapeHtml(r.date)}">${escapeHtml(formatDate(r.date))}</time>
+                                <span class="field-report-chip">${meta.icon} ${escapeHtml(meta.label)}</span>
+                            </div>
+                            <h3 class="field-report-title">${titleHtml}</h3>
+                            ${bylineHtml ? `<p class="field-report-byline">${bylineHtml}</p>` : ''}
+                            ${r.description ? `<p class="field-report-desc">${escapeHtml(r.description)}</p>` : ''}
+                        </div>
+                    </li>
+                `;
+            }).join('');
+
+            fieldReportsContainer.innerHTML = `<ol class="field-reports-timeline">${items}</ol>`;
+        };
+
+        const showReportsFallback = (errMsg) => {
+            const detail = errMsg ? ` <code>${escapeHtml(errMsg)}</code>` : '';
+            fieldReportsContainer.innerHTML = `<p class="field-reports-empty">Field reports unavailable right now.${detail}</p>`;
+        };
+
+        // Resolve URL relative to the loaded custom.js script so it works
+        // regardless of page depth or deployment subpath.
+        let reportsUrl = '_static/field-reports.json';
+        const scriptEl = document.querySelector('script[src*="custom.js"]');
+        if (scriptEl) {
+            try {
+                reportsUrl = new URL('field-reports.json', scriptEl.src).href;
+            } catch (e) {
+                // fall through to relative fallback
             }
         }
 
-        // Fetch from API
-        fetch('https://api.github.com/repos/anistark/feluda/contributors')
+        fetch(reportsUrl, { cache: 'no-cache' })
             .then(response => {
-                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`);
                 return response.json();
             })
-            .then(contributors => {
-                localStorage.setItem(CACHE_KEY, JSON.stringify({ data: contributors, timestamp: Date.now() }));
-                renderContributors(contributors);
-            })
+            .then(renderReports)
             .catch(error => {
-                console.error('Failed to fetch contributors:', error);
-                // Try to use stale cache if available
-                if (cached) {
-                    renderContributors(JSON.parse(cached).data);
-                } else {
-                    showFallback();
-                }
+                console.error('Failed to load field reports:', error);
+                showReportsFallback(error.message || String(error));
             });
     }
 });

--- a/docs/source/_static/field-reports.json
+++ b/docs/source/_static/field-reports.json
@@ -1,0 +1,33 @@
+[
+  {
+    "title": "From types to trust: safer API design in Rust",
+    "speaker": "Farhaan Bukhsh",
+    "venue": "Rust India 2025, Bengaluru",
+    "date": "2026-04-18",
+    "type": "video",
+    "url": "https://www.youtube.com/watch?v=PRsq5iYXPA4"
+  },
+  {
+    "title": "Feluda CLI: Detecting License Risks in Your Dependencies",
+    "speaker": "Farhaan Bukhsh",
+    "venue": "EuroPython 2025, Prague",
+    "date": "2025-07-18",
+    "type": "lightning"
+  },
+  {
+    "title": "Detect license usage restrictions in your project",
+    "speaker": "Kumar Anirudha, Farhaan Bukhsh",
+    "venue": "FOSS United, Bengaluru",
+    "date": "2025-05-24",
+    "type": "talk",
+    "url": "https://fossunited.org/c/bengaluru/may-2025/cfp/2rt9houfgc"
+  },
+  {
+    "title": "How safe is your Product License?",
+    "speaker": "Kumar Anirudha",
+    "venue": "Cyber Secure India, Bengaluru",
+    "date": "2025-05-17",
+    "type": "slides",
+    "url": "https://anistark.github.io/talks/feluda.pdf"
+  }
+]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,6 +71,16 @@ Thanks to all the people who contribute to Feluda!
 
    <div id="contributors-container">Loading contributors...</div>
 
+Field Reports 🔎
+----------------
+
+Talks, videos, slides, and upcoming appearances where Feluda steps out of the codebase.
+Have a session to share? `Open a PR <https://github.com/anistark/feluda/edit/main/docs/source/_static/field-reports.json>`_ to add it.
+
+.. raw:: html
+
+   <div id="field-reports-container">Loading field reports...</div>
+
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Add a "Field Reports" section below Contributors that surfaces talks, videos, slides, and upcoming appearances where Feluda has been featured. Entries render as a vertical timeline with a continuous purple rail, pulsing dots (green for upcoming), glassmorphic cards, and whole-card click targets.

Data lives in `docs/source/_static/field-reports.json` and is sorted by date, most recent first. Each entry takes:

    title, speaker, venue, date (YYYY-MM-DD), type, url

`type` is one of `video`, `slides`, `talk`, `lightning`, `upcoming`, `article`, or `podcast`, and drives the chip label and icon. The repo-wide `*.json` ignore is overridden for this single file so the data is committed.

Also wraps the contributors block in an IIFE. Its early `return` on a fresh localStorage cache was leaking to the parent `DOMContentLoaded` handler, silently skipping anything added after it — which broke the new timeline on every reload until the cache expired.