### PR TITLE
feat(licenses): parse compound SPDX expressions

### DIFF
--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -1,5 +1,6 @@
 //! Core license analysis functionality and types
 
+use crate::spdx;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -553,22 +554,19 @@ fn get_osi_licenses() -> &'static HashMap<String, OsiStatus> {
     }
 }
 
-/// Check OSI approval status for a license
-pub fn get_osi_status(license_id: &str) -> OsiStatus {
+/// Check OSI approval status for a license ID (single, non-compound).
+fn get_osi_status_single(license_id: &str) -> OsiStatus {
     let normalized_id = normalize_license_id(license_id);
     let osi_licenses = get_osi_licenses();
 
-    // Check for exact match first
     if let Some(status) = osi_licenses.get(&normalized_id) {
         return *status;
     }
 
-    // Check for original license ID
     if let Some(status) = osi_licenses.get(license_id) {
         return *status;
     }
 
-    // For well-known licenses, we can provide static mappings as fallback
     match normalized_id.as_str() {
         "MIT" | "Apache-2.0" | "BSD-3-Clause" | "BSD-2-Clause" | "GPL-3.0" | "GPL-2.0"
         | "LGPL-3.0" | "LGPL-2.1" | "MPL-2.0" | "ISC" | "0BSD" => OsiStatus::Approved,
@@ -577,7 +575,56 @@ pub fn get_osi_status(license_id: &str) -> OsiStatus {
     }
 }
 
-/// Check if a license is considered restrictive based on configuration and known licenses
+/// Check OSI approval status for a license string, which may be a compound SPDX expression.
+pub fn get_osi_status(license_id: &str) -> OsiStatus {
+    if spdx::is_compound(license_id) {
+        let expr = spdx::parse(license_id);
+        return spdx::expression_osi_status(&expr, &get_osi_status_single);
+    }
+    get_osi_status_single(license_id)
+}
+
+/// Check if a single (non-compound) license ID is restrictive.
+fn is_single_license_restrictive(
+    license_str: &str,
+    known_licenses: &HashMap<String, License>,
+    config: &config::FeludaConfig,
+    strict: bool,
+) -> bool {
+    if let Some(license_data) = known_licenses.get(license_str) {
+        let conditions = if strict {
+            vec![
+                "source-disclosure",
+                "network-use-disclosure",
+                "disclose-source",
+                "same-license",
+            ]
+        } else {
+            vec!["source-disclosure", "network-use-disclosure"]
+        };
+        return conditions
+            .iter()
+            .any(|&c| license_data.conditions.contains(&c.to_string()));
+    }
+
+    let is_restrictive = config
+        .licenses
+        .restrictive
+        .iter()
+        .any(|r| license_str.contains(r.as_str()));
+
+    if !is_restrictive && strict && license_str.contains("Unknown") {
+        return true;
+    }
+
+    is_restrictive
+}
+
+/// Check if a license is considered restrictive based on configuration and known licenses.
+///
+/// Handles compound SPDX expressions:
+///   - `OR`  → not restrictive if ANY alternative is permissive.
+///   - `AND` → restrictive if ANY component is restrictive.
 pub fn is_license_restrictive(
     license: &Option<String>,
     known_licenses: &HashMap<String, License>,
@@ -589,13 +636,9 @@ pub fn is_license_restrictive(
     );
 
     let config = match config::load_config() {
-        Ok(cfg) => {
-            log(LogLevel::Info, "Successfully loaded configuration");
-            cfg
-        }
+        Ok(cfg) => cfg,
         Err(e) => {
             log_error("Error loading configuration", &e);
-            log(LogLevel::Warn, "Using default configuration");
             config::FeludaConfig::default()
         }
     };
@@ -614,66 +657,31 @@ pub fn is_license_restrictive(
             &known_licenses.keys().collect::<Vec<_>>(),
         );
 
-        if let Some(license_data) = known_licenses.get(license_str) {
-            log_debug("Found license data", license_data);
-
-            let conditions = if strict {
-                vec![
-                    "source-disclosure",
-                    "network-use-disclosure",
-                    "disclose-source",
-                    "same-license",
-                ]
-            } else {
-                vec!["source-disclosure", "network-use-disclosure"]
-            };
-
-            let is_restrictive = conditions
-                .iter()
-                .any(|&condition| license_data.conditions.contains(&condition.to_string()));
-
-            if is_restrictive {
-                log(
-                    LogLevel::Warn,
-                    &format!("License {license_str} is restrictive due to conditions"),
-                );
-            } else {
-                log(
-                    LogLevel::Info,
-                    &format!("License {license_str} is not restrictive"),
-                );
-            }
-
-            return is_restrictive;
-        } else {
-            let is_restrictive = config
-                .licenses
-                .restrictive
-                .iter()
-                .any(|restrictive_license| license_str.contains(restrictive_license));
-
-            if is_restrictive {
-                log(
-                    LogLevel::Warn,
-                    &format!("License {license_str} matches restrictive pattern in config"),
-                );
-            } else if strict && license_str.contains("Unknown") {
-                log(
-                    LogLevel::Warn,
-                    &format!(
-                        "License {license_str} is unknown in strict mode, considering restrictive"
-                    ),
-                );
-                return true;
-            } else {
-                log(
-                    LogLevel::Info,
-                    &format!("License {license_str} does not match any restrictive pattern"),
-                );
-            }
-
-            return is_restrictive;
+        if spdx::is_compound(license_str) {
+            let expr = spdx::parse(license_str);
+            let result = spdx::expression_is_restrictive(&expr, &|id| {
+                is_single_license_restrictive(id, known_licenses, &config, strict)
+            });
+            log(
+                LogLevel::Info,
+                &format!("Compound expression '{license_str}' is_restrictive={result}"),
+            );
+            return result;
         }
+
+        let result = is_single_license_restrictive(license_str, known_licenses, &config, strict);
+        if result {
+            log(
+                LogLevel::Warn,
+                &format!("License {license_str} is restrictive"),
+            );
+        } else {
+            log(
+                LogLevel::Info,
+                &format!("License {license_str} is not restrictive"),
+            );
+        }
+        return result;
     }
 
     if strict {
@@ -883,7 +891,39 @@ fn get_compatibility_matrix() -> &'static HashMap<String, Vec<String>> {
     }
 }
 
-/// Check if a license is compatible with the base project license
+/// Check if a single (non-compound) dependency license ID is compatible with the project license.
+fn is_single_license_compatible(
+    dependency_license: &str,
+    project_license: &str,
+    strict: bool,
+) -> LicenseCompatibility {
+    let compatibility_matrix = get_compatibility_matrix();
+    let norm_dep = normalize_license_id(dependency_license);
+    let norm_proj = normalize_license_id(project_license);
+
+    match compatibility_matrix.get(&norm_proj) {
+        Some(compatible_licenses) => {
+            if compatible_licenses.contains(&norm_dep) {
+                LicenseCompatibility::Compatible
+            } else {
+                LicenseCompatibility::Incompatible
+            }
+        }
+        None => {
+            if strict {
+                LicenseCompatibility::Incompatible
+            } else {
+                LicenseCompatibility::Unknown
+            }
+        }
+    }
+}
+
+/// Check if a license is compatible with the base project license.
+///
+/// Handles compound SPDX expressions in `dependency_license`:
+///   - `OR`  → compatible if ANY alternative is compatible with the project license.
+///   - `AND` → compatible only if ALL components are compatible.
 pub fn is_license_compatible(
     dependency_license: &str,
     project_license: &str,
@@ -892,57 +932,29 @@ pub fn is_license_compatible(
     log(
         LogLevel::Info,
         &format!(
-            "Checking if dependency license {dependency_license} is compatible with project license {project_license} (strict={strict})"
+            "Checking compatibility: dependency={dependency_license} project={project_license} strict={strict}"
         ),
     );
 
-    let compatibility_matrix = get_compatibility_matrix();
-    let norm_dependency_license = normalize_license_id(dependency_license);
-    let norm_project_license = normalize_license_id(project_license);
+    if spdx::is_compound(dependency_license) {
+        let expr = spdx::parse(dependency_license);
+        let result =
+            spdx::expression_compatibility(&expr, project_license, strict, &|dep, proj, s| {
+                is_single_license_compatible(dep, proj, s)
+            });
+        log(
+            LogLevel::Info,
+            &format!("Compound expression '{dependency_license}' compatibility={result}"),
+        );
+        return result;
+    }
 
+    let result = is_single_license_compatible(dependency_license, project_license, strict);
     log(
         LogLevel::Info,
-        &format!(
-            "Normalized licenses: dependency={norm_dependency_license}, project={norm_project_license}"
-        ),
+        &format!("License {dependency_license} compatibility with {project_license}: {result}"),
     );
-
-    match compatibility_matrix.get(&norm_project_license) {
-        Some(compatible_licenses) => {
-            if compatible_licenses.contains(&norm_dependency_license) {
-                log(
-                    LogLevel::Info,
-                    &format!(
-                        "License {norm_dependency_license} is compatible with project license {norm_project_license}"
-                    ),
-                );
-                LicenseCompatibility::Compatible
-            } else {
-                log(
-                    LogLevel::Warn,
-                    &format!(
-                        "License {norm_dependency_license} may be incompatible with project license {norm_project_license}"
-                    ),
-                );
-                LicenseCompatibility::Incompatible
-            }
-        }
-        None => {
-            if strict {
-                log(
-                    LogLevel::Warn,
-                    &format!("Unknown compatibility for project license {norm_project_license} in strict mode, marking as incompatible"),
-                );
-                LicenseCompatibility::Incompatible
-            } else {
-                log(
-                    LogLevel::Warn,
-                    &format!("Unknown compatibility for project license {norm_project_license}"),
-                );
-                LicenseCompatibility::Unknown
-            }
-        }
-    }
+    result
 }
 
 /// Normalize license identifier to a standard format

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod licenses;
 mod parser;
 mod reporter;
 mod sbom;
+mod spdx;
 mod table;
 mod utils;
 

--- a/src/spdx.rs
+++ b/src/spdx.rs
@@ -1,0 +1,466 @@
+//! SPDX expression parsing and evaluation.
+//!
+//! Handles compound expressions like `MIT OR Apache-2.0`, `(MIT AND BSD-2-Clause)`,
+//! and `GPL-2.0-only WITH Classpath-exception-2.0`.
+//!
+//! Operator semantics used by Feluda:
+//!   - `OR`  — user may choose any alternative; compatible/non-restrictive if ANY component qualifies.
+//!   - `AND` — all licenses apply simultaneously; compatible/non-restrictive only if ALL qualify.
+//!   - `WITH`— exception modifier; treated as an annotation on the base license.
+
+/// A parsed SPDX expression tree.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpdxExpression {
+    License(String),
+    With { license: String, exception: String },
+    Or(Box<SpdxExpression>, Box<SpdxExpression>),
+    And(Box<SpdxExpression>, Box<SpdxExpression>),
+}
+
+impl SpdxExpression {
+    /// Returns all individual license IDs mentioned in the expression (no exceptions).
+    #[allow(dead_code)]
+    pub fn license_ids(&self) -> Vec<String> {
+        match self {
+            Self::License(id) => vec![id.clone()],
+            Self::With { license, .. } => vec![license.clone()],
+            Self::Or(a, b) | Self::And(a, b) => {
+                let mut ids = a.license_ids();
+                ids.extend(b.license_ids());
+                ids
+            }
+        }
+    }
+}
+
+/// Parse an SPDX expression string into an [`SpdxExpression`] tree.
+///
+/// Returns the original string wrapped in `License` if parsing fails, so call
+/// sites degrade gracefully rather than erroring out.
+pub fn parse(input: &str) -> SpdxExpression {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return SpdxExpression::License(input.to_string());
+    }
+
+    let tokens = tokenize(trimmed);
+    let mut pos = 0;
+    parse_or_expr(&tokens, &mut pos).unwrap_or_else(|| SpdxExpression::License(input.to_string()))
+}
+
+/// Returns `true` when `input` looks like a compound SPDX expression (contains
+/// ` OR `, ` AND `, ` WITH `, or parentheses) rather than a plain license ID.
+pub fn is_compound(input: &str) -> bool {
+    input.contains(" OR ")
+        || input.contains(" AND ")
+        || input.contains(" WITH ")
+        || input.contains('(')
+}
+
+// ── Tokeniser ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Id(String),
+    Or,
+    And,
+    With,
+    LParen,
+    RParen,
+}
+
+fn tokenize(input: &str) -> Vec<Token> {
+    let mut tokens = Vec::new();
+    let mut chars = input.chars().peekable();
+
+    while let Some(&ch) = chars.peek() {
+        match ch {
+            '(' => {
+                chars.next();
+                tokens.push(Token::LParen);
+            }
+            ')' => {
+                chars.next();
+                tokens.push(Token::RParen);
+            }
+            ' ' | '\t' => {
+                chars.next();
+            }
+            _ => {
+                // Peek-based accumulation so delimiters are never consumed by this branch.
+                let mut word = String::new();
+                while let Some(&c) = chars.peek() {
+                    if c == ' ' || c == '\t' || c == '(' || c == ')' {
+                        break;
+                    }
+                    word.push(c);
+                    chars.next();
+                }
+                match word.as_str() {
+                    "OR" => tokens.push(Token::Or),
+                    "AND" => tokens.push(Token::And),
+                    "WITH" => tokens.push(Token::With),
+                    _ => tokens.push(Token::Id(word)),
+                }
+            }
+        }
+    }
+    tokens
+}
+
+// ── Recursive descent parser ─────────────────────────────────────────────────
+
+fn parse_or_expr(tokens: &[Token], pos: &mut usize) -> Option<SpdxExpression> {
+    let mut left = parse_and_expr(tokens, pos)?;
+
+    while *pos < tokens.len() {
+        if tokens[*pos] == Token::Or {
+            *pos += 1;
+            let right = parse_and_expr(tokens, pos)?;
+            left = SpdxExpression::Or(Box::new(left), Box::new(right));
+        } else {
+            break;
+        }
+    }
+    Some(left)
+}
+
+fn parse_and_expr(tokens: &[Token], pos: &mut usize) -> Option<SpdxExpression> {
+    let mut left = parse_with_expr(tokens, pos)?;
+
+    while *pos < tokens.len() {
+        if tokens[*pos] == Token::And {
+            *pos += 1;
+            let right = parse_with_expr(tokens, pos)?;
+            left = SpdxExpression::And(Box::new(left), Box::new(right));
+        } else {
+            break;
+        }
+    }
+    Some(left)
+}
+
+fn parse_with_expr(tokens: &[Token], pos: &mut usize) -> Option<SpdxExpression> {
+    let base = parse_primary(tokens, pos)?;
+
+    if *pos < tokens.len() && tokens[*pos] == Token::With {
+        *pos += 1;
+        if let Some(Token::Id(exception)) = tokens.get(*pos) {
+            let exception = exception.clone();
+            *pos += 1;
+            if let SpdxExpression::License(license) = base {
+                return Some(SpdxExpression::With { license, exception });
+            }
+        }
+    }
+    Some(base)
+}
+
+fn parse_primary(tokens: &[Token], pos: &mut usize) -> Option<SpdxExpression> {
+    match tokens.get(*pos)? {
+        Token::LParen => {
+            *pos += 1;
+            let expr = parse_or_expr(tokens, pos)?;
+            if tokens.get(*pos) == Some(&Token::RParen) {
+                *pos += 1;
+            }
+            Some(expr)
+        }
+        Token::Id(id) => {
+            let id = id.clone();
+            *pos += 1;
+            Some(SpdxExpression::License(id))
+        }
+        _ => None,
+    }
+}
+
+// ── Compatibility / restrictiveness evaluation ────────────────────────────────
+
+/// Evaluate compatibility of an SPDX expression against the project license.
+///
+/// - `OR`  → compatible if ANY branch is compatible.
+/// - `AND` → compatible only if ALL branches are compatible.
+/// - Plain or `WITH` → delegate to the base license check.
+pub fn expression_compatibility(
+    expr: &SpdxExpression,
+    project_license: &str,
+    strict: bool,
+    check_fn: &dyn Fn(&str, &str, bool) -> crate::licenses::LicenseCompatibility,
+) -> crate::licenses::LicenseCompatibility {
+    use crate::licenses::LicenseCompatibility;
+
+    match expr {
+        SpdxExpression::License(id) => check_fn(id, project_license, strict),
+        SpdxExpression::With { license, .. } => check_fn(license, project_license, strict),
+
+        SpdxExpression::Or(a, b) => {
+            let ca = expression_compatibility(a, project_license, strict, check_fn);
+            let cb = expression_compatibility(b, project_license, strict, check_fn);
+            match (ca, cb) {
+                (LicenseCompatibility::Compatible, _) | (_, LicenseCompatibility::Compatible) => {
+                    LicenseCompatibility::Compatible
+                }
+                (LicenseCompatibility::Unknown, _) | (_, LicenseCompatibility::Unknown) => {
+                    LicenseCompatibility::Unknown
+                }
+                _ => LicenseCompatibility::Incompatible,
+            }
+        }
+
+        SpdxExpression::And(a, b) => {
+            let ca = expression_compatibility(a, project_license, strict, check_fn);
+            let cb = expression_compatibility(b, project_license, strict, check_fn);
+            match (ca, cb) {
+                (LicenseCompatibility::Incompatible, _)
+                | (_, LicenseCompatibility::Incompatible) => LicenseCompatibility::Incompatible,
+                (LicenseCompatibility::Compatible, LicenseCompatibility::Compatible) => {
+                    LicenseCompatibility::Compatible
+                }
+                _ => LicenseCompatibility::Unknown,
+            }
+        }
+    }
+}
+
+/// Evaluate restrictiveness of an SPDX expression.
+///
+/// - `OR`  → not restrictive if ANY branch is not restrictive (user can choose the permissive option).
+/// - `AND` → restrictive if ANY branch is restrictive (all licenses apply).
+pub fn expression_is_restrictive(expr: &SpdxExpression, check_fn: &dyn Fn(&str) -> bool) -> bool {
+    match expr {
+        SpdxExpression::License(id) => check_fn(id),
+        SpdxExpression::With { license, .. } => check_fn(license),
+        SpdxExpression::Or(a, b) => {
+            expression_is_restrictive(a, check_fn) && expression_is_restrictive(b, check_fn)
+        }
+        SpdxExpression::And(a, b) => {
+            expression_is_restrictive(a, check_fn) || expression_is_restrictive(b, check_fn)
+        }
+    }
+}
+
+/// Evaluate OSI status of an SPDX expression.
+///
+/// - `OR`  → approved if ANY branch is approved.
+/// - `AND` → approved only if ALL branches are approved.
+pub fn expression_osi_status(
+    expr: &SpdxExpression,
+    check_fn: &dyn Fn(&str) -> crate::licenses::OsiStatus,
+) -> crate::licenses::OsiStatus {
+    use crate::licenses::OsiStatus;
+
+    match expr {
+        SpdxExpression::License(id) => check_fn(id),
+        SpdxExpression::With { license, .. } => check_fn(license),
+
+        SpdxExpression::Or(a, b) => {
+            let sa = expression_osi_status(a, check_fn);
+            let sb = expression_osi_status(b, check_fn);
+            match (sa, sb) {
+                (OsiStatus::Approved, _) | (_, OsiStatus::Approved) => OsiStatus::Approved,
+                (OsiStatus::Unknown, _) | (_, OsiStatus::Unknown) => OsiStatus::Unknown,
+                _ => OsiStatus::NotApproved,
+            }
+        }
+
+        SpdxExpression::And(a, b) => {
+            let sa = expression_osi_status(a, check_fn);
+            let sb = expression_osi_status(b, check_fn);
+            match (sa, sb) {
+                (OsiStatus::NotApproved, _) | (_, OsiStatus::NotApproved) => OsiStatus::NotApproved,
+                (OsiStatus::Approved, OsiStatus::Approved) => OsiStatus::Approved,
+                _ => OsiStatus::Unknown,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple() {
+        assert_eq!(parse("MIT"), SpdxExpression::License("MIT".to_string()));
+    }
+
+    #[test]
+    fn test_parse_or() {
+        assert_eq!(
+            parse("MIT OR Apache-2.0"),
+            SpdxExpression::Or(
+                Box::new(SpdxExpression::License("MIT".to_string())),
+                Box::new(SpdxExpression::License("Apache-2.0".to_string())),
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_and() {
+        assert_eq!(
+            parse("MIT AND BSD-2-Clause"),
+            SpdxExpression::And(
+                Box::new(SpdxExpression::License("MIT".to_string())),
+                Box::new(SpdxExpression::License("BSD-2-Clause".to_string())),
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_with() {
+        assert_eq!(
+            parse("GPL-2.0-only WITH Classpath-exception-2.0"),
+            SpdxExpression::With {
+                license: "GPL-2.0-only".to_string(),
+                exception: "Classpath-exception-2.0".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_parenthesized() {
+        let expr = parse("(MIT OR Apache-2.0)");
+        assert_eq!(
+            expr,
+            SpdxExpression::Or(
+                Box::new(SpdxExpression::License("MIT".to_string())),
+                Box::new(SpdxExpression::License("Apache-2.0".to_string())),
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_nested() {
+        let expr = parse("(MIT OR Apache-2.0) AND BSD-2-Clause");
+        assert_eq!(
+            expr,
+            SpdxExpression::And(
+                Box::new(SpdxExpression::Or(
+                    Box::new(SpdxExpression::License("MIT".to_string())),
+                    Box::new(SpdxExpression::License("Apache-2.0".to_string())),
+                )),
+                Box::new(SpdxExpression::License("BSD-2-Clause".to_string())),
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_triple_or() {
+        let expr = parse("MIT OR Apache-2.0 OR BSD-2-Clause");
+        let ids = match expr {
+            SpdxExpression::Or(left, right) => {
+                let mut ids = left.license_ids();
+                ids.extend(right.license_ids());
+                ids
+            }
+            _ => panic!("expected Or"),
+        };
+        assert!(ids.contains(&"MIT".to_string()));
+        assert!(ids.contains(&"Apache-2.0".to_string()));
+        assert!(ids.contains(&"BSD-2-Clause".to_string()));
+    }
+
+    #[test]
+    fn test_license_ids_or() {
+        let expr = parse("MIT OR Apache-2.0");
+        let ids = expr.license_ids();
+        assert_eq!(ids, vec!["MIT", "Apache-2.0"]);
+    }
+
+    #[test]
+    fn test_license_ids_with() {
+        let expr = parse("GPL-2.0-only WITH Classpath-exception-2.0");
+        assert_eq!(expr.license_ids(), vec!["GPL-2.0-only"]);
+    }
+
+    #[test]
+    fn test_is_compound() {
+        assert!(is_compound("MIT OR Apache-2.0"));
+        assert!(is_compound("MIT AND BSD-2-Clause"));
+        assert!(is_compound("GPL-2.0-only WITH Classpath-exception-2.0"));
+        assert!(is_compound("(MIT OR Apache-2.0)"));
+        assert!(!is_compound("MIT"));
+        assert!(!is_compound("Apache-2.0"));
+    }
+
+    #[test]
+    fn test_expression_compatibility_or_one_compatible() {
+        use crate::licenses::LicenseCompatibility;
+
+        let expr = parse("MIT OR GPL-3.0");
+        let result = expression_compatibility(&expr, "MIT", false, &|dep, proj, _| {
+            if dep == "MIT" && proj == "MIT" {
+                LicenseCompatibility::Compatible
+            } else {
+                LicenseCompatibility::Incompatible
+            }
+        });
+        assert_eq!(result, LicenseCompatibility::Compatible);
+    }
+
+    #[test]
+    fn test_expression_compatibility_and_one_incompatible() {
+        use crate::licenses::LicenseCompatibility;
+
+        let expr = parse("MIT AND GPL-3.0");
+        let result = expression_compatibility(&expr, "MIT", false, &|dep, proj, _| {
+            if dep == "MIT" && proj == "MIT" {
+                LicenseCompatibility::Compatible
+            } else {
+                LicenseCompatibility::Incompatible
+            }
+        });
+        assert_eq!(result, LicenseCompatibility::Incompatible);
+    }
+
+    #[test]
+    fn test_expression_is_restrictive_or_one_permissive() {
+        let expr = parse("MIT OR GPL-3.0");
+        let result = expression_is_restrictive(&expr, &|id| id == "GPL-3.0");
+        assert!(
+            !result,
+            "OR with one permissive option should not be restrictive"
+        );
+    }
+
+    #[test]
+    fn test_expression_is_restrictive_and_one_restrictive() {
+        let expr = parse("MIT AND GPL-3.0");
+        let result = expression_is_restrictive(&expr, &|id| id == "GPL-3.0");
+        assert!(
+            result,
+            "AND with one restrictive component should be restrictive"
+        );
+    }
+
+    #[test]
+    fn test_expression_osi_status_or_one_approved() {
+        use crate::licenses::OsiStatus;
+
+        let expr = parse("MIT OR LicenseRef-Custom");
+        let result = expression_osi_status(&expr, &|id| {
+            if id == "MIT" {
+                OsiStatus::Approved
+            } else {
+                OsiStatus::Unknown
+            }
+        });
+        assert_eq!(result, OsiStatus::Approved);
+    }
+
+    #[test]
+    fn test_expression_osi_status_and_one_not_approved() {
+        use crate::licenses::OsiStatus;
+
+        let expr = parse("MIT AND LicenseRef-Custom");
+        let result = expression_osi_status(&expr, &|id| {
+            if id == "MIT" {
+                OsiStatus::Approved
+            } else {
+                OsiStatus::NotApproved
+            }
+        });
+        assert_eq!(result, OsiStatus::NotApproved);
+    }
+}


### PR DESCRIPTION
Previously, a license string like `MIT OR Apache-2.0` was treated as an opaque identifier. It would fail compatibility and restrictiveness checks because no matrix entry matched the full compound string.

Adds `src/spdx.rs` — a recursive descent parser that converts an SPDX expression string into a typed `SpdxExpression` tree supporting `OR`, `AND`, `WITH`, and parenthesised sub-expressions. Operator precedence follows the SPDX 2.3 spec: OR < AND < WITH.

Evaluation semantics:

- `OR`  — compatible / non-restrictive if ANY alternative qualifies (the user is free to choose the permissive option).
- `AND` — compatible only if ALL components are compatible; restrictive if ANY component is restrictive (all licenses apply at once).
- `WITH`— exception treated as an annotation on the base license ID.

`is_license_compatible`, `is_license_restrictive`, and `get_osi_status` in `licenses.rs` now detect compound expressions via `spdx::is_compound` and delegate to the evaluators before falling back to plain ID lookups. Plain license IDs take the same code path as before — no regression.