### PR TITLE
feat(parser): add monorepo workspace support across Cargo, npm, Go, and uv

### DIFF
--- a/docs/source/cli/output.rst
+++ b/docs/source/cli/output.rst
@@ -25,7 +25,10 @@ Machine-readable JSON for downstream automation.
 
    feluda --json
 
-Feluda emits a JSON array containing dependency names, versions, licenses, restriction flags, and OSI status.
+Feluda emits a JSON array containing dependency names, versions, licenses,
+restriction flags, and OSI status. When scanning a workspace or monorepo, each
+entry also carries a ``sub_project`` field listing the workspace member(s) that
+pull in that dependency. The field is omitted on single-project scans.
 
 YAML Format
 ^^^^^^^^^^^
@@ -89,7 +92,9 @@ Extra columns including OSI status in standard output.
 
    feluda --verbose
 
-Feluda adds OSI status and extended descriptions to the CLI table.
+Feluda adds OSI status and extended descriptions to the CLI table. In a
+workspace or monorepo scan, the verbose table also includes a **Sub-project**
+column showing which workspace member(s) own each dependency.
 
 Debug Mode
 ^^^^^^^^^^

--- a/docs/source/cli/scan.rst
+++ b/docs/source/cli/scan.rst
@@ -93,6 +93,51 @@ Feluda clones the repository into a temporary location, performs the scan, and r
 
 ----
 
+Scan a Workspace or Monorepo
+----------------------------
+
+Feluda automatically detects multi-package projects and produces one unified
+report covering every sub-project, so you don't have to run separate scans.
+
+**Cargo workspaces** — point Feluda at the workspace root (the directory
+containing the ``[workspace]`` ``Cargo.toml``). Workspace members themselves
+are excluded from the report; their transitive dependencies are attributed to
+the member that pulls them in.
+
+**npm/yarn/pnpm workspaces** — point Feluda at the directory containing the
+root ``package.json`` with the ``workspaces`` field. Each dependency is
+attributed to the workspace package(s) that declare it.
+
+**Go workspaces** — point Feluda at the directory containing ``go.work``.
+Feluda parses the ``use`` directives, scans each member module, and merges
+the results.
+
+.. code-block:: bash
+
+   feluda --path /path/to/monorepo
+
+In a monorepo scan, Feluda's standard table grows a *Workspace breakdown*
+section listing the dependency count per sub-project:
+
+.. code-block:: text
+
+   📦 Total dependencies scanned: 142
+
+   🧩 Workspace breakdown:
+     • 98 api
+     • 76 worker
+     • 42 cli
+
+In ``--verbose`` mode, the table also gains a **Sub-project** column showing
+which workspace member(s) pulled in each dependency. Shared dependencies list
+all owners separated by commas.
+
+In ``--json`` and ``--yaml`` output, every dependency carries an optional
+``sub_project`` field. The field is omitted entirely for non-workspace scans
+to keep the schema stable.
+
+----
+
 Control Local vs Remote Detection
 ---------------------------------
 

--- a/docs/source/cli/scan.rst
+++ b/docs/source/cli/scan.rst
@@ -112,6 +112,11 @@ attributed to the workspace package(s) that declare it.
 Feluda parses the ``use`` directives, scans each member module, and merges
 the results.
 
+**Python uv workspaces** — point Feluda at the directory containing the root
+``pyproject.toml`` with a ``[tool.uv.workspace]`` section. Feluda expands the
+``members`` glob list (honoring ``exclude``), reads each member's
+``pyproject.toml``, and attributes every declared dependency to its member.
+
 .. code-block:: bash
 
    feluda --path /path/to/monorepo

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -60,6 +60,14 @@ Conflict Detection
 Highlights dependencies whose licenses may conflict with your project's terms.
 Get early warnings about incompatibilities before they affect your release.
 
+Workspace & Monorepo Support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Detects Cargo workspaces, npm/yarn/pnpm workspaces, and Go workspaces
+(``go.work``) and produces a single unified report across every sub-project.
+Each dependency is attributed to the workspace member(s) that pull it in, so
+you can see at a glance which package introduced a restrictive license.
+
 ----
 
 Compliance & Reporting

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -63,10 +63,11 @@ Get early warnings about incompatibilities before they affect your release.
 Workspace & Monorepo Support
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Detects Cargo workspaces, npm/yarn/pnpm workspaces, and Go workspaces
-(``go.work``) and produces a single unified report across every sub-project.
-Each dependency is attributed to the workspace member(s) that pull it in, so
-you can see at a glance which package introduced a restrictive license.
+Detects Cargo workspaces, npm/yarn/pnpm workspaces, Go workspaces
+(``go.work``), and Python uv workspaces (``[tool.uv.workspace]``) and
+produces a single unified report across every sub-project. Each dependency
+is attributed to the workspace member(s) that pull it in, so you can see at
+a glance which package introduced a restrictive license.
 
 ----
 

--- a/docs/source/supported-languages.rst
+++ b/docs/source/supported-languages.rst
@@ -80,19 +80,19 @@ Feluda currently supports projects written in these ecosystems:
      - Notes
    * - Rust
      - ``Cargo.toml``, ``Cargo.lock``
-     - Cargo package manager
+     - Cargo package manager; Cargo workspaces supported
    * - Go
-     - ``go.mod``, ``go.sum``
-     - Go modules
+     - ``go.mod``, ``go.sum``, ``go.work``
+     - Go modules and Go workspaces (``go.work``)
    * - Python
      - ``requirements.txt``, ``Pipfile``, ``pyproject.toml``
      - pip, pipenv, poetry
    * - JavaScript / TypeScript
      - ``package.json``, ``package-lock.json``
-     - npm, pnpm, yarn, bun
+     - npm, pnpm, yarn, bun; npm/yarn/pnpm workspaces supported
    * - Node.js
      - ``package.json``, ``package-lock.json``
-     - npm, pnpm, yarn, bun
+     - npm, pnpm, yarn, bun; npm/yarn/pnpm workspaces supported
    * - C
      - ``conanfile.txt``, ``conanfile.py``
      - Conan package manager

--- a/docs/source/supported-languages.rst
+++ b/docs/source/supported-languages.rst
@@ -86,7 +86,7 @@ Feluda currently supports projects written in these ecosystems:
      - Go modules and Go workspaces (``go.work``)
    * - Python
      - ``requirements.txt``, ``Pipfile``, ``pyproject.toml``
-     - pip, pipenv, poetry
+     - pip, pipenv, poetry; uv workspaces supported
    * - JavaScript / TypeScript
      - ``package.json``, ``package-lock.json``
      - npm, pnpm, yarn, bun; npm/yarn/pnpm workspaces supported

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1413,6 +1413,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "tokio".to_string(),
@@ -1421,6 +1422,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ]
     }
@@ -1658,6 +1660,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package2".to_string(),
@@ -1666,6 +1669,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package3".to_string(),
@@ -1674,6 +1678,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1720,6 +1725,7 @@ mod tests {
             is_restrictive: true,
             compatibility: LicenseCompatibility::Unknown,
             osi_status: crate::licenses::OsiStatus::Unknown,
+            sub_project: None,
         }];
 
         let content = generate_notice_content(&test_data);
@@ -1759,6 +1765,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         generate_notice_file(&license_data, path);
@@ -1790,6 +1797,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         generate_notice_file(&license_data, path);
@@ -1813,6 +1821,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         generate_third_party_licenses_file(&license_data, path);

--- a/src/languages/c.rs
+++ b/src/languages/c.rs
@@ -84,6 +84,7 @@ pub fn analyze_c_licenses(project_path: &str, config: &FeludaConfig) -> Vec<Lice
                     Some(l) => crate::licenses::get_osi_status(l),
                     None => crate::licenses::OsiStatus::Unknown,
                 },
+                sub_project: None,
             }
         })
         .collect()

--- a/src/languages/cpp.rs
+++ b/src/languages/cpp.rs
@@ -103,6 +103,7 @@ pub fn analyze_cpp_licenses(project_path: &str, config: &FeludaConfig) -> Vec<Li
                     Some(l) => crate::licenses::get_osi_status(l),
                     None => crate::licenses::OsiStatus::Unknown,
                 },
+                sub_project: None,
             }
         })
         .collect()

--- a/src/languages/dotnet.rs
+++ b/src/languages/dotnet.rs
@@ -104,6 +104,7 @@ pub fn analyze_dotnet_licenses(project_path: &str, config: &FeludaConfig) -> Vec
                 Some(l) => crate::licenses::get_osi_status(l),
                 None => crate::licenses::OsiStatus::Unknown,
             },
+            sub_project: None,
         });
     }
 

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -98,6 +98,7 @@ pub fn analyze_go_licenses(go_mod_path: &str, config: &FeludaConfig) -> Vec<Lice
                 Some(l) => crate::licenses::get_osi_status(l),
                 None => crate::licenses::OsiStatus::Unknown,
             },
+            sub_project: None,
         });
     }
 
@@ -106,6 +107,193 @@ pub fn analyze_go_licenses(go_mod_path: &str, config: &FeludaConfig) -> Vec<Lice
         &format!("Found {} Go dependencies with licenses", licenses.len()),
     );
     licenses
+}
+
+/// Analyze a Go workspace (go.work) by scanning each `use` directory's go.mod and
+/// attributing every dependency to the workspace member it belongs to. Deps shared by
+/// multiple members are listed under all of them.
+pub fn analyze_go_workspace_licenses(
+    workspace_root: &std::path::Path,
+    config: &FeludaConfig,
+) -> Vec<LicenseInfo> {
+    let go_work_path = workspace_root.join("go.work");
+    log(
+        LogLevel::Info,
+        &format!("Reading Go workspace file: {}", go_work_path.display()),
+    );
+
+    let content = match fs::read_to_string(&go_work_path) {
+        Ok(c) => c,
+        Err(err) => {
+            log_error(
+                &format!("Failed to read go.work: {}", go_work_path.display()),
+                &err,
+            );
+            return Vec::new();
+        }
+    };
+
+    let use_dirs = parse_go_work_use_directives(&content);
+    log(
+        LogLevel::Info,
+        &format!("go.work has {} use directives", use_dirs.len()),
+    );
+    log_debug("go.work use directives", &use_dirs);
+
+    if use_dirs.is_empty() {
+        log(
+            LogLevel::Warn,
+            "go.work has no use directives; nothing to scan",
+        );
+        return Vec::new();
+    }
+
+    let mut merged: HashMap<(String, String), (LicenseInfo, std::collections::BTreeSet<String>)> =
+        HashMap::new();
+
+    for rel_dir in &use_dirs {
+        let member_path = workspace_root.join(rel_dir);
+        let member_go_mod = member_path.join("go.mod");
+        if !member_go_mod.exists() {
+            log(
+                LogLevel::Warn,
+                &format!(
+                    "go.work member missing go.mod, skipping: {}",
+                    member_go_mod.display()
+                ),
+            );
+            continue;
+        }
+
+        let member_name = read_go_module_name(&member_go_mod).unwrap_or_else(|| rel_dir.clone());
+        log(
+            LogLevel::Info,
+            &format!(
+                "Scanning workspace member '{}' at {}",
+                member_name,
+                member_path.display()
+            ),
+        );
+
+        let member_path_str = match member_go_mod.to_str() {
+            Some(s) => s,
+            None => {
+                log(LogLevel::Error, "Failed to convert member go.mod to string");
+                continue;
+            }
+        };
+
+        let member_deps = analyze_go_licenses(member_path_str, config);
+        log(
+            LogLevel::Info,
+            &format!(
+                "Member '{}' contributed {} deps",
+                member_name,
+                member_deps.len()
+            ),
+        );
+
+        for info in member_deps {
+            let key = (info.name.clone(), info.version.clone());
+            let entry = merged
+                .entry(key)
+                .or_insert_with(|| (info.clone(), std::collections::BTreeSet::new()));
+            entry.1.insert(member_name.clone());
+        }
+    }
+
+    let mut result: Vec<LicenseInfo> = merged
+        .into_iter()
+        .map(|(_, (mut info, members))| {
+            info.sub_project = Some(members.into_iter().collect::<Vec<_>>().join(", "));
+            info
+        })
+        .collect();
+
+    log(
+        LogLevel::Info,
+        &format!(
+            "Go workspace analysis produced {} unique deps",
+            result.len()
+        ),
+    );
+
+    result.sort_by(|a, b| a.name.cmp(&b.name));
+    result
+}
+
+/// Parse `use (...)` and bare `use ./path` directives from go.work content.
+pub fn parse_go_work_use_directives(content: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    let stripped = strip_go_line_comments(content);
+
+    let mut iter = stripped.lines().peekable();
+    while let Some(raw) = iter.next() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix("use") {
+            let rest = rest.trim();
+            if let Some(stripped) = rest.strip_prefix('(') {
+                let mut block = String::from(stripped);
+                if !rest.ends_with(')') {
+                    for inner in iter.by_ref() {
+                        let l = inner.trim();
+                        if l == ")" || l.ends_with(')') {
+                            block.push(' ');
+                            block.push_str(l.trim_end_matches(')'));
+                            break;
+                        }
+                        block.push(' ');
+                        block.push_str(l);
+                    }
+                } else {
+                    block = block.trim_end_matches(')').to_string();
+                }
+                for tok in block.split_whitespace() {
+                    let t = tok.trim_matches(|c: char| c == '"' || c == ',');
+                    if !t.is_empty() && t != "(" && t != ")" {
+                        result.push(t.to_string());
+                    }
+                }
+            } else if !rest.is_empty() {
+                let t = rest.trim_matches(|c: char| c == '"' || c == ',');
+                if !t.is_empty() {
+                    result.push(t.to_string());
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Read the `module` declaration from a go.mod file.
+pub fn read_go_module_name(go_mod_path: &std::path::Path) -> Option<String> {
+    let content = fs::read_to_string(go_mod_path).ok()?;
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("module") {
+            let name = rest.trim().trim_matches('"').to_string();
+            if !name.is_empty() {
+                return Some(name);
+            }
+        }
+    }
+    None
+}
+
+fn strip_go_line_comments(content: &str) -> String {
+    content
+        .lines()
+        .map(|l| match l.find("//") {
+            Some(i) => &l[..i],
+            None => l,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Parse Go dependencies from go.mod content
@@ -974,5 +1162,64 @@ github.com/level2@v1.0.0 github.com/level3@v1.0.0"#;
         let (name, version) = result.unwrap();
         assert_eq!(name, "github.com/user/repo");
         assert_eq!(version, "v1.2.3");
+    }
+
+    #[test]
+    fn test_parse_go_work_use_directives_block() {
+        let content = r#"go 1.22
+
+use (
+    ./api
+    ./worker
+    ./shared
+)
+"#;
+        let dirs = parse_go_work_use_directives(content);
+        assert_eq!(dirs, vec!["./api", "./worker", "./shared"]);
+    }
+
+    #[test]
+    fn test_parse_go_work_use_directives_single() {
+        let content = "go 1.22\n\nuse ./only\n";
+        let dirs = parse_go_work_use_directives(content);
+        assert_eq!(dirs, vec!["./only"]);
+    }
+
+    #[test]
+    fn test_parse_go_work_use_directives_with_comments() {
+        let content = r#"go 1.22
+
+use (
+    ./api      // public api
+    ./worker   // background worker
+)
+"#;
+        let dirs = parse_go_work_use_directives(content);
+        assert_eq!(dirs, vec!["./api", "./worker"]);
+    }
+
+    #[test]
+    fn test_parse_go_work_use_directives_empty() {
+        assert!(parse_go_work_use_directives("go 1.22\n").is_empty());
+    }
+
+    #[test]
+    fn test_read_go_module_name() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("go.mod");
+        std::fs::write(&path, "module github.com/example/svc\n\ngo 1.22\n").unwrap();
+        assert_eq!(
+            read_go_module_name(&path),
+            Some("github.com/example/svc".to_string())
+        );
+    }
+
+    #[test]
+    fn test_analyze_go_workspace_licenses_empty_workspace() {
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(temp.path().join("go.work"), "go 1.22\n").unwrap();
+        let cfg = crate::config::FeludaConfig::default();
+        let result = analyze_go_workspace_licenses(temp.path(), &cfg);
+        assert!(result.is_empty());
     }
 }

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -47,6 +47,7 @@ impl Language {
             "Cargo.toml" => Some(Language::Rust("Cargo.toml")),
             "package.json" => Some(Language::Node("package.json")),
             "go.mod" => Some(Language::Go("go.mod")),
+            "go.work" => Some(Language::Go("go.work")),
             "vcpkg.json" => Some(Language::Cpp(&CPP_PATHS[..])),
             "conanfile.txt" | "conanfile.py" => Some(Language::Cpp(&CPP_PATHS[..])),
             "MODULE.bazel" => Some(Language::Cpp(&CPP_PATHS[..])),

--- a/src/languages/node.rs
+++ b/src/languages/node.rs
@@ -318,6 +318,17 @@ pub fn analyze_js_licenses_with_config(
         }
     };
 
+    let attribution = build_npm_workspace_attribution(project_root, package_json_path);
+    if !attribution.is_empty() {
+        log(
+            LogLevel::Info,
+            &format!(
+                "Built npm workspace attribution for {} unique deps across members",
+                attribution.len()
+            ),
+        );
+    }
+
     // Process dependencies in parallel
     all_dependencies
         .par_iter()
@@ -333,6 +344,10 @@ pub fn analyze_js_licenses_with_config(
                 );
             }
 
+            let sub_project = attribution
+                .get(name)
+                .map(|members| members.iter().cloned().collect::<Vec<_>>().join(", "));
+
             LicenseInfo {
                 name: name.to_string(),
                 version: clean_version_string(version),
@@ -340,9 +355,132 @@ pub fn analyze_js_licenses_with_config(
                 is_restrictive,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::get_osi_status(&license),
+                sub_project,
             }
         })
         .collect()
+}
+
+/// Build a map from dep name -> set of workspace member names that declare it.
+///
+/// Returns an empty map for non-workspace projects. The root package's own deps are
+/// attributed to the root package name (or "root" if unnamed).
+fn build_npm_workspace_attribution(
+    project_root: &Path,
+    package_json_path: &str,
+) -> HashMap<String, std::collections::BTreeSet<String>> {
+    let mut attribution: HashMap<String, std::collections::BTreeSet<String>> = HashMap::new();
+
+    let root_content = match fs::read_to_string(package_json_path) {
+        Ok(c) => c,
+        Err(_) => return attribution,
+    };
+    let root_json: Value = match serde_json::from_str(&root_content) {
+        Ok(v) => v,
+        Err(_) => return attribution,
+    };
+
+    let workspaces = match root_json.get("workspaces") {
+        Some(w) => w,
+        None => return attribution,
+    };
+
+    log(LogLevel::Info, "Building npm workspace attribution map");
+
+    let patterns: Vec<&str> = if let Some(arr) = workspaces.as_array() {
+        arr.iter().filter_map(|v| v.as_str()).collect()
+    } else if let Some(obj) = workspaces.as_object() {
+        obj.get("packages")
+            .and_then(|p| p.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default()
+    } else {
+        return attribution;
+    };
+
+    let root_name = root_json
+        .get("name")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| "root".to_string());
+    record_direct_deps_from_json(&root_json, &root_name, &mut attribution);
+
+    for pattern in patterns {
+        for dir in expand_workspace_pattern(project_root, pattern) {
+            let pkg_json = dir.join("package.json");
+            if !pkg_json.exists() {
+                continue;
+            }
+            let content = match fs::read_to_string(&pkg_json) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let json: Value = match serde_json::from_str(&content) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            let member_name = json
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .unwrap_or_else(|| {
+                    dir.file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("unknown")
+                        .to_string()
+                });
+
+            record_direct_deps_from_json(&json, &member_name, &mut attribution);
+        }
+    }
+
+    attribution
+}
+
+fn record_direct_deps_from_json(
+    json: &Value,
+    member_name: &str,
+    attribution: &mut HashMap<String, std::collections::BTreeSet<String>>,
+) {
+    for key in [
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ] {
+        if let Some(deps) = json.get(key).and_then(|v| v.as_object()) {
+            for dep_name in deps.keys() {
+                attribution
+                    .entry(dep_name.clone())
+                    .or_default()
+                    .insert(member_name.to_string());
+            }
+        }
+    }
+}
+
+fn expand_workspace_pattern(project_root: &Path, pattern: &str) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    if let Some(stripped) = pattern.strip_suffix("/*") {
+        let parent = project_root.join(stripped);
+        if parent.is_dir() {
+            if let Ok(entries) = fs::read_dir(&parent) {
+                for entry in entries.flatten() {
+                    let p = entry.path();
+                    if p.is_dir() {
+                        result.push(p);
+                    }
+                }
+            }
+        }
+    } else {
+        let p = project_root.join(pattern);
+        if p.is_dir() {
+            result.push(p);
+        }
+    }
+    result
 }
 
 fn try_all_dependency_detection_methods(
@@ -2591,5 +2729,109 @@ mod tests {
 
         let result = get_license_from_local_license_file(temp_dir.path(), "test-pkg");
         assert_eq!(result, Some("BSD".to_string()));
+    }
+
+    #[test]
+    fn test_npm_workspace_attribution_array_form() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+
+        let root_pkg = serde_json::json!({
+            "name": "monorepo-root",
+            "workspaces": ["packages/*"],
+            "dependencies": { "lodash": "^4.0.0" }
+        });
+        fs::write(
+            root.join("package.json"),
+            serde_json::to_string(&root_pkg).unwrap(),
+        )
+        .unwrap();
+
+        let pkg_a = root.join("packages/api");
+        fs::create_dir_all(&pkg_a).unwrap();
+        fs::write(
+            pkg_a.join("package.json"),
+            serde_json::json!({
+                "name": "@org/api",
+                "dependencies": { "express": "^4.0.0", "lodash": "^4.0.0" }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let pkg_b = root.join("packages/cli");
+        fs::create_dir_all(&pkg_b).unwrap();
+        fs::write(
+            pkg_b.join("package.json"),
+            serde_json::json!({
+                "name": "@org/cli",
+                "dependencies": { "yargs": "^17.0.0" }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let attribution =
+            build_npm_workspace_attribution(root, root.join("package.json").to_str().unwrap());
+
+        let lodash = attribution.get("lodash").expect("lodash attributed");
+        assert!(lodash.contains("monorepo-root"));
+        assert!(lodash.contains("@org/api"));
+        assert_eq!(lodash.len(), 2);
+
+        let express = attribution.get("express").expect("express attributed");
+        assert_eq!(express.iter().next().unwrap(), "@org/api");
+
+        let yargs = attribution.get("yargs").expect("yargs attributed");
+        assert_eq!(yargs.iter().next().unwrap(), "@org/cli");
+    }
+
+    #[test]
+    fn test_npm_workspace_attribution_object_form() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+
+        fs::write(
+            root.join("package.json"),
+            serde_json::json!({
+                "name": "root",
+                "workspaces": { "packages": ["apps/*"] }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let app = root.join("apps/web");
+        fs::create_dir_all(&app).unwrap();
+        fs::write(
+            app.join("package.json"),
+            serde_json::json!({
+                "name": "web",
+                "devDependencies": { "vitest": "^1.0.0" }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let attribution =
+            build_npm_workspace_attribution(root, root.join("package.json").to_str().unwrap());
+        let vitest = attribution.get("vitest").expect("vitest attributed");
+        assert_eq!(vitest.iter().next().unwrap(), "web");
+    }
+
+    #[test]
+    fn test_npm_workspace_attribution_no_workspaces() {
+        let temp = tempfile::TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("package.json"),
+            r#"{"name": "single", "dependencies": {"foo": "1.0"}}"#,
+        )
+        .unwrap();
+
+        let attribution = build_npm_workspace_attribution(
+            temp.path(),
+            temp.path().join("package.json").to_str().unwrap(),
+        );
+        assert!(attribution.is_empty());
     }
 }

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -1,9 +1,9 @@
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use toml::Value as TomlValue;
 
@@ -140,92 +140,74 @@ pub fn analyze_python_licenses(package_file_path: &str, config: &FeludaConfig) -
 
     // Check if it's a pyproject.toml file
     if package_file_path.ends_with("pyproject.toml") {
+        let project_root = Path::new(package_file_path)
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let attribution = build_uv_workspace_attribution(&project_root, package_file_path);
+        if !attribution.is_empty() {
+            log(
+                LogLevel::Info,
+                &format!(
+                    "Built uv workspace attribution for {} unique deps across members",
+                    attribution.len()
+                ),
+            );
+        }
+
         match fs::read_to_string(package_file_path) {
             Ok(content) => match toml::from_str::<TomlValue>(&content) {
                 Ok(toml_config) => {
-                    if let Some(project) = toml_config.as_table().and_then(|t| t.get("project")) {
-                        if let Some(deps) = project
-                            .as_table()
-                            .and_then(|t| t.get("dependencies"))
-                            .and_then(|d| d.as_array())
-                        {
-                            log(
-                                LogLevel::Info,
-                                &format!("Found {} Python dependencies", deps.len()),
-                            );
-                            log_debug("Dependencies", deps);
+                    let mut direct_deps = extract_pep508_deps_from_toml(&toml_config);
+                    let is_workspace = is_uv_workspace_root(&toml_config);
 
-                            // First collect direct dependencies
-                            let mut direct_deps = Vec::new();
-                            for dep in deps {
-                                if let Some(dep_str) = dep.as_str() {
-                                    let (name, version) = if let Some((n, v)) = dep_str
-                                        .split_once("==")
-                                        .or_else(|| dep_str.split_once(">="))
-                                        .or_else(|| dep_str.split_once(">"))
-                                        .or_else(|| dep_str.split_once("~="))
-                                        .or_else(|| dep_str.split_once("<="))
-                                        .or_else(|| dep_str.split_once("<"))
-                                    {
-                                        (n.trim(), v.trim())
-                                    } else {
-                                        (dep_str.trim(), "latest")
-                                    };
-
-                                    direct_deps.push((name.to_string(), version.to_string()));
-                                }
+                    if is_workspace {
+                        let member_dirs =
+                            collect_uv_workspace_member_dirs(&project_root, &toml_config);
+                        log(
+                            LogLevel::Info,
+                            &format!(
+                                "uv workspace detected; merging deps from {} members",
+                                member_dirs.len()
+                            ),
+                        );
+                        for member_dir in &member_dirs {
+                            let member_pyproject = member_dir.join("pyproject.toml");
+                            if !member_pyproject.exists() {
+                                continue;
                             }
-
-                            // Try to resolve all dependencies (direct + transitive) using uv or fallback to PyPI
-                            let max_depth = config.dependencies.max_depth;
-                            log(
-                                LogLevel::Info,
-                                &format!("Using max dependency depth: {max_depth}"),
-                            );
-                            let all_deps = resolve_python_dependencies(
-                                &direct_deps,
-                                package_file_path,
-                                max_depth,
-                            );
-
-                            // Process all resolved dependencies
-                            for (name, version) in all_deps {
-                                log(
-                                    LogLevel::Info,
-                                    &format!("Processing dependency: {name} ({version})"),
-                                );
-
-                                let license_result =
-                                    fetch_license_for_python_dependency(&name, &version);
-                                let license = Some(license_result);
-                                let is_restrictive = is_license_restrictive(
-                                    &license,
-                                    &known_licenses,
-                                    config.strict,
-                                );
-
-                                if is_restrictive {
+                            if let Ok(c) = fs::read_to_string(&member_pyproject) {
+                                if let Ok(member_toml) = toml::from_str::<TomlValue>(&c) {
+                                    let extra = extract_pep508_deps_from_toml(&member_toml);
                                     log(
-                                        LogLevel::Warn,
+                                        LogLevel::Info,
                                         &format!(
-                                            "Restrictive license found: {license:?} for {name}"
+                                            "Member {} contributed {} direct deps",
+                                            member_dir.display(),
+                                            extra.len()
                                         ),
                                     );
+                                    direct_deps.extend(extra);
                                 }
-
-                                licenses.push(LicenseInfo {
-                                    name,
-                                    version,
-                                    license: license.clone(),
-                                    is_restrictive,
-                                    compatibility: LicenseCompatibility::Unknown,
-                                    osi_status: match &license {
-                                        Some(l) => crate::licenses::get_osi_status(l),
-                                        None => crate::licenses::OsiStatus::Unknown,
-                                    },
-                                    sub_project: None,
-                                });
                             }
+                        }
+
+                        let mut seen = HashSet::new();
+                        direct_deps.retain(|(n, _)| seen.insert(n.clone()));
+                    }
+
+                    if direct_deps.is_empty() {
+                        if is_workspace {
+                            log(LogLevel::Warn, "uv workspace has no member dependencies");
+                        } else if toml_config
+                            .as_table()
+                            .and_then(|t| t.get("project"))
+                            .is_none()
+                        {
+                            log(
+                                LogLevel::Warn,
+                                "No 'project' section found in pyproject.toml",
+                            );
                         } else {
                             log(
                                 LogLevel::Warn,
@@ -234,9 +216,57 @@ pub fn analyze_python_licenses(package_file_path: &str, config: &FeludaConfig) -
                         }
                     } else {
                         log(
-                            LogLevel::Warn,
-                            "No 'project' section found in pyproject.toml",
+                            LogLevel::Info,
+                            &format!("Found {} direct Python dependencies", direct_deps.len()),
                         );
+                        log_debug("Direct dependencies", &direct_deps);
+
+                        // Try to resolve all dependencies (direct + transitive) using uv or fallback to PyPI
+                        let max_depth = config.dependencies.max_depth;
+                        log(
+                            LogLevel::Info,
+                            &format!("Using max dependency depth: {max_depth}"),
+                        );
+                        let all_deps =
+                            resolve_python_dependencies(&direct_deps, package_file_path, max_depth);
+
+                        // Process all resolved dependencies
+                        for (name, version) in all_deps {
+                            log(
+                                LogLevel::Info,
+                                &format!("Processing dependency: {name} ({version})"),
+                            );
+
+                            let license_result =
+                                fetch_license_for_python_dependency(&name, &version);
+                            let license = Some(license_result);
+                            let is_restrictive =
+                                is_license_restrictive(&license, &known_licenses, config.strict);
+
+                            if is_restrictive {
+                                log(
+                                    LogLevel::Warn,
+                                    &format!("Restrictive license found: {license:?} for {name}"),
+                                );
+                            }
+
+                            let sub_project = attribution.get(&name).map(|members| {
+                                members.iter().cloned().collect::<Vec<_>>().join(", ")
+                            });
+
+                            licenses.push(LicenseInfo {
+                                name,
+                                version,
+                                license: license.clone(),
+                                is_restrictive,
+                                compatibility: LicenseCompatibility::Unknown,
+                                osi_status: match &license {
+                                    Some(l) => crate::licenses::get_osi_status(l),
+                                    None => crate::licenses::OsiStatus::Unknown,
+                                },
+                                sub_project,
+                            });
+                        }
                     }
                 }
                 Err(err) => {
@@ -1007,6 +1037,207 @@ fn parse_version_constraint(constraint: &str) -> Option<(&str, &str)> {
     }
 }
 
+/// Extract direct deps from a parsed pyproject.toml's `[project] dependencies` array.
+/// Returns (name, version) pairs; version is "latest" when no constraint is present.
+fn extract_pep508_deps_from_toml(toml_config: &TomlValue) -> Vec<(String, String)> {
+    let mut deps = Vec::new();
+    if let Some(arr) = toml_config
+        .as_table()
+        .and_then(|t| t.get("project"))
+        .and_then(|p| p.as_table())
+        .and_then(|t| t.get("dependencies"))
+        .and_then(|d| d.as_array())
+    {
+        for dep in arr {
+            if let Some(dep_str) = dep.as_str() {
+                deps.push(split_pep508_dep(dep_str));
+            }
+        }
+    }
+    deps
+}
+
+fn split_pep508_dep(dep_str: &str) -> (String, String) {
+    if let Some((n, v)) = dep_str
+        .split_once("==")
+        .or_else(|| dep_str.split_once(">="))
+        .or_else(|| dep_str.split_once(">"))
+        .or_else(|| dep_str.split_once("~="))
+        .or_else(|| dep_str.split_once("<="))
+        .or_else(|| dep_str.split_once("<"))
+    {
+        (n.trim().to_string(), v.trim().to_string())
+    } else {
+        (dep_str.trim().to_string(), "latest".to_string())
+    }
+}
+
+fn is_uv_workspace_root(toml_config: &TomlValue) -> bool {
+    toml_config
+        .as_table()
+        .and_then(|t| t.get("tool"))
+        .and_then(|t| t.as_table())
+        .and_then(|t| t.get("uv"))
+        .and_then(|u| u.as_table())
+        .and_then(|u| u.get("workspace"))
+        .is_some()
+}
+
+/// Expand a `[tool.uv.workspace]` block into a list of member directories.
+///
+/// Honors the `members` glob list and the optional `exclude` patterns. The exclude
+/// match is intentionally simple — it strips a trailing `/*` and compares the prefix.
+fn collect_uv_workspace_member_dirs(project_root: &Path, toml_config: &TomlValue) -> Vec<PathBuf> {
+    let workspace = match toml_config
+        .as_table()
+        .and_then(|t| t.get("tool"))
+        .and_then(|t| t.get("uv"))
+        .and_then(|u| u.get("workspace"))
+        .and_then(|w| w.as_table())
+    {
+        Some(w) => w,
+        None => return Vec::new(),
+    };
+
+    let members: Vec<&str> = workspace
+        .get("members")
+        .and_then(|m| m.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    let exclude: Vec<&str> = workspace
+        .get("exclude")
+        .and_then(|m| m.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    let mut result = Vec::new();
+    for pattern in members {
+        for dir in expand_uv_member_pattern(project_root, pattern) {
+            if !is_uv_member_excluded(&dir, project_root, &exclude) {
+                result.push(dir);
+            }
+        }
+    }
+    result
+}
+
+fn expand_uv_member_pattern(project_root: &Path, pattern: &str) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    if let Some(stripped) = pattern.strip_suffix("/*") {
+        let parent = project_root.join(stripped);
+        if parent.is_dir() {
+            if let Ok(entries) = fs::read_dir(&parent) {
+                for entry in entries.flatten() {
+                    let p = entry.path();
+                    if p.is_dir() {
+                        result.push(p);
+                    }
+                }
+            }
+        }
+    } else {
+        let p = project_root.join(pattern);
+        if p.is_dir() {
+            result.push(p);
+        }
+    }
+    result
+}
+
+fn is_uv_member_excluded(dir: &Path, project_root: &Path, exclude: &[&str]) -> bool {
+    let rel = match dir.strip_prefix(project_root) {
+        Ok(r) => r.to_string_lossy().replace('\\', "/"),
+        Err(_) => return false,
+    };
+    for pat in exclude {
+        let prefix = pat.strip_suffix("/*").unwrap_or(pat);
+        if rel == prefix || rel.starts_with(&format!("{prefix}/")) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Build a map from dep name -> set of workspace member names that declare it.
+///
+/// Returns an empty map for non-workspace pyproject.toml files. The root project's
+/// own deps are attributed to its `[project] name` (or "root" if unnamed).
+fn build_uv_workspace_attribution(
+    project_root: &Path,
+    pyproject_path: &str,
+) -> HashMap<String, BTreeSet<String>> {
+    let mut attribution: HashMap<String, BTreeSet<String>> = HashMap::new();
+
+    let root_content = match fs::read_to_string(pyproject_path) {
+        Ok(c) => c,
+        Err(_) => return attribution,
+    };
+    let root_toml: TomlValue = match toml::from_str(&root_content) {
+        Ok(v) => v,
+        Err(_) => return attribution,
+    };
+
+    if !is_uv_workspace_root(&root_toml) {
+        return attribution;
+    }
+
+    let root_name = root_toml
+        .as_table()
+        .and_then(|t| t.get("project"))
+        .and_then(|p| p.as_table())
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| "root".to_string());
+    record_uv_direct_deps(&root_toml, &root_name, &mut attribution);
+
+    for member_dir in collect_uv_workspace_member_dirs(project_root, &root_toml) {
+        let member_pyproject = member_dir.join("pyproject.toml");
+        if !member_pyproject.exists() {
+            continue;
+        }
+        let content = match fs::read_to_string(&member_pyproject) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let member_toml: TomlValue = match toml::from_str(&content) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let member_name = member_toml
+            .as_table()
+            .and_then(|t| t.get("project"))
+            .and_then(|p| p.as_table())
+            .and_then(|p| p.get("name"))
+            .and_then(|n| n.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| {
+                member_dir
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("unknown")
+                    .to_string()
+            });
+        record_uv_direct_deps(&member_toml, &member_name, &mut attribution);
+    }
+
+    attribution
+}
+
+fn record_uv_direct_deps(
+    toml_config: &TomlValue,
+    member_name: &str,
+    attribution: &mut HashMap<String, BTreeSet<String>>,
+) {
+    for (dep_name, _) in extract_pep508_deps_from_toml(toml_config) {
+        attribution
+            .entry(dep_name)
+            .or_default()
+            .insert(member_name.to_string());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1229,5 +1460,182 @@ mod tests {
 
         let marker2 = EnvironmentMarker::parse("sys_platform == 'darwin'");
         assert!(marker2.unwrap().applies_to_environment());
+    }
+
+    #[test]
+    fn test_split_pep508_dep_variants() {
+        assert_eq!(
+            split_pep508_dep("fastapi==0.115.0"),
+            ("fastapi".to_string(), "0.115.0".to_string())
+        );
+        assert_eq!(
+            split_pep508_dep("click>=8.0"),
+            ("click".to_string(), "8.0".to_string())
+        );
+        assert_eq!(
+            split_pep508_dep("requests~=2.31.0"),
+            ("requests".to_string(), "2.31.0".to_string())
+        );
+        assert_eq!(
+            split_pep508_dep("celery"),
+            ("celery".to_string(), "latest".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_pep508_deps_from_toml() {
+        let toml_content = r#"
+[project]
+name = "demo"
+dependencies = ["fastapi==0.115.0", "click>=8.0", "no-version"]
+"#;
+        let parsed: TomlValue = toml::from_str(toml_content).unwrap();
+        let deps = extract_pep508_deps_from_toml(&parsed);
+        assert_eq!(deps.len(), 3);
+        assert!(deps.iter().any(|(n, v)| n == "fastapi" && v == "0.115.0"));
+        assert!(deps.iter().any(|(n, v)| n == "click" && v == "8.0"));
+        assert!(deps.iter().any(|(n, v)| n == "no-version" && v == "latest"));
+    }
+
+    #[test]
+    fn test_is_uv_workspace_root_detects_workspace() {
+        let with_workspace = toml::from_str::<TomlValue>(
+            r#"
+[project]
+name = "monorepo"
+
+[tool.uv.workspace]
+members = ["packages/*"]
+"#,
+        )
+        .unwrap();
+        assert!(is_uv_workspace_root(&with_workspace));
+
+        let without_workspace = toml::from_str::<TomlValue>(
+            r#"
+[project]
+name = "single"
+dependencies = []
+"#,
+        )
+        .unwrap();
+        assert!(!is_uv_workspace_root(&without_workspace));
+    }
+
+    #[test]
+    fn test_collect_uv_workspace_member_dirs_globs_and_excludes() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        for sub in &[
+            "services/api",
+            "services/worker",
+            "services/legacy",
+            "packages/shared",
+        ] {
+            std::fs::create_dir_all(root.join(sub)).unwrap();
+        }
+
+        let toml_config: TomlValue = toml::from_str(
+            r#"
+[project]
+name = "monorepo"
+
+[tool.uv.workspace]
+members = ["services/*", "packages/*"]
+exclude = ["services/legacy"]
+"#,
+        )
+        .unwrap();
+
+        let dirs = collect_uv_workspace_member_dirs(root, &toml_config);
+        let names: BTreeSet<String> = dirs
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str()).map(String::from))
+            .collect();
+
+        assert!(names.contains("api"));
+        assert!(names.contains("worker"));
+        assert!(names.contains("shared"));
+        assert!(
+            !names.contains("legacy"),
+            "legacy was excluded but still surfaced"
+        );
+    }
+
+    #[test]
+    fn test_build_uv_workspace_attribution_root_and_members() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+
+        std::fs::write(
+            root.join("pyproject.toml"),
+            r#"
+[project]
+name = "monorepo-root"
+dependencies = ["click>=8.0"]
+
+[tool.uv.workspace]
+members = ["services/*"]
+"#,
+        )
+        .unwrap();
+
+        let api = root.join("services/api");
+        std::fs::create_dir_all(&api).unwrap();
+        std::fs::write(
+            api.join("pyproject.toml"),
+            r#"
+[project]
+name = "api-service"
+dependencies = ["fastapi==0.115.0", "click>=8.0"]
+"#,
+        )
+        .unwrap();
+
+        let worker = root.join("services/worker");
+        std::fs::create_dir_all(&worker).unwrap();
+        std::fs::write(
+            worker.join("pyproject.toml"),
+            r#"
+[project]
+name = "worker-service"
+dependencies = ["celery>=5.0"]
+"#,
+        )
+        .unwrap();
+
+        let attribution =
+            build_uv_workspace_attribution(root, root.join("pyproject.toml").to_str().unwrap());
+
+        let click = attribution.get("click").expect("click attributed");
+        assert!(click.contains("monorepo-root"));
+        assert!(click.contains("api-service"));
+        assert_eq!(click.len(), 2);
+
+        let fastapi = attribution.get("fastapi").expect("fastapi attributed");
+        assert_eq!(fastapi.iter().next().unwrap(), "api-service");
+
+        let celery = attribution.get("celery").expect("celery attributed");
+        assert_eq!(celery.iter().next().unwrap(), "worker-service");
+    }
+
+    #[test]
+    fn test_build_uv_workspace_attribution_returns_empty_for_non_workspace() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("pyproject.toml"),
+            r#"
+[project]
+name = "single"
+dependencies = ["click>=8.0"]
+"#,
+        )
+        .unwrap();
+
+        let attribution = build_uv_workspace_attribution(
+            temp.path(),
+            temp.path().join("pyproject.toml").to_str().unwrap(),
+        );
+        assert!(attribution.is_empty());
     }
 }

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -223,6 +223,7 @@ pub fn analyze_python_licenses(package_file_path: &str, config: &FeludaConfig) -
                                         Some(l) => crate::licenses::get_osi_status(l),
                                         None => crate::licenses::OsiStatus::Unknown,
                                     },
+                                    sub_project: None,
                                 });
                             }
                         } else {
@@ -322,6 +323,7 @@ pub fn analyze_python_licenses(package_file_path: &str, config: &FeludaConfig) -
                             Some(l) => crate::licenses::get_osi_status(l),
                             None => crate::licenses::OsiStatus::Unknown,
                         },
+                        sub_project: None,
                     });
                 }
 

--- a/src/languages/r.rs
+++ b/src/languages/r.rs
@@ -103,6 +103,7 @@ fn parse_renv_lock(
                                 Some(l) => crate::licenses::get_osi_status(l),
                                 None => crate::licenses::OsiStatus::Unknown,
                             },
+                            sub_project: None,
                         });
                     }
                 } else {
@@ -176,6 +177,7 @@ fn parse_description_file(
                         Some(l) => crate::licenses::get_osi_status(l),
                         None => crate::licenses::OsiStatus::Unknown,
                     },
+                    sub_project: None,
                 });
             }
         }

--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -1,8 +1,8 @@
-use cargo_metadata::Package;
+use cargo_metadata::{Metadata, Package, PackageId};
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
-use crate::debug::{log, log_error, LogLevel};
+use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
     fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
 };
@@ -14,12 +14,121 @@ pub fn analyze_rust_licenses(packages: Vec<Package>) -> Vec<LicenseInfo> {
     analyze_rust_licenses_with_config(packages, &config, false)
 }
 
-pub fn analyze_rust_licenses_with_no_local(
-    packages: Vec<Package>,
+/// Analyze Rust deps with full Metadata so workspace members can be attributed.
+///
+/// In a multi-member Cargo workspace, every dependency is tagged with the workspace
+/// member(s) that pull it in, and workspace members themselves are excluded from the
+/// dep report. Single-crate projects fall through to the existing behavior.
+pub fn analyze_rust_licenses_with_metadata(
+    metadata: Metadata,
+    config: &crate::config::FeludaConfig,
     no_local: bool,
 ) -> Vec<LicenseInfo> {
-    let config = crate::config::load_config().unwrap_or_default();
-    analyze_rust_licenses_with_config(packages, &config, no_local)
+    let workspace_members: HashSet<PackageId> =
+        metadata.workspace_members.iter().cloned().collect();
+    let is_workspace = workspace_members.len() > 1;
+
+    log(
+        LogLevel::Info,
+        &format!(
+            "Cargo metadata: {} workspace members, {} total packages",
+            workspace_members.len(),
+            metadata.packages.len()
+        ),
+    );
+
+    if !is_workspace {
+        log(
+            LogLevel::Info,
+            "Single-crate project; no workspace attribution",
+        );
+        return analyze_rust_licenses_with_config(metadata.packages, config, no_local);
+    }
+
+    let attribution = build_workspace_attribution(&metadata, &workspace_members);
+    log_debug("Workspace attribution map", &attribution);
+
+    let dep_packages: Vec<Package> = metadata
+        .packages
+        .into_iter()
+        .filter(|p| !workspace_members.contains(&p.id))
+        .collect();
+
+    log(
+        LogLevel::Info,
+        &format!(
+            "Analyzing {} non-workspace deps across workspace",
+            dep_packages.len()
+        ),
+    );
+
+    let mut infos = analyze_rust_licenses_with_config(dep_packages, config, no_local);
+    for info in &mut infos {
+        if let Some(member_names) = attribution.get(&(info.name.clone(), info.version.clone())) {
+            if !member_names.is_empty() {
+                info.sub_project =
+                    Some(member_names.iter().cloned().collect::<Vec<_>>().join(", "));
+            }
+        }
+    }
+    infos
+}
+
+/// Build a map from (dep name, version) -> set of workspace member names that depend on it.
+fn build_workspace_attribution(
+    metadata: &Metadata,
+    workspace_members: &HashSet<PackageId>,
+) -> HashMap<(String, String), BTreeSet<String>> {
+    let mut attribution: HashMap<(String, String), BTreeSet<String>> = HashMap::new();
+
+    let resolve = match &metadata.resolve {
+        Some(r) => r,
+        None => {
+            log(LogLevel::Warn, "No resolve graph in cargo metadata");
+            return attribution;
+        }
+    };
+
+    let nodes_by_id: HashMap<&PackageId, &cargo_metadata::Node> =
+        resolve.nodes.iter().map(|n| (&n.id, n)).collect();
+    let pkg_by_id: HashMap<&PackageId, &Package> =
+        metadata.packages.iter().map(|p| (&p.id, p)).collect();
+
+    for member_id in workspace_members {
+        let member_name = match pkg_by_id.get(member_id) {
+            Some(p) => p.name.to_string(),
+            None => continue,
+        };
+
+        let mut visited: HashSet<&PackageId> = HashSet::new();
+        let mut queue: VecDeque<&PackageId> = VecDeque::new();
+        queue.push_back(member_id);
+        visited.insert(member_id);
+
+        while let Some(id) = queue.pop_front() {
+            let node = match nodes_by_id.get(id) {
+                Some(n) => *n,
+                None => continue,
+            };
+            for dep_id in &node.dependencies {
+                if !visited.insert(dep_id) {
+                    continue;
+                }
+                queue.push_back(dep_id);
+                if workspace_members.contains(dep_id) {
+                    continue;
+                }
+                if let Some(pkg) = pkg_by_id.get(dep_id) {
+                    attribution
+                        .entry((pkg.name.to_string(), pkg.version.to_string()))
+                        .or_default()
+                        .insert(member_name.clone());
+                }
+            }
+        }
+    }
+
+    attribution
 }
 
 pub fn analyze_rust_licenses_with_config(
@@ -92,6 +201,7 @@ pub fn analyze_rust_licenses_with_config(
                     Some(license) => crate::licenses::get_osi_status(license),
                     None => crate::licenses::OsiStatus::Unknown,
                 },
+                sub_project: None,
             }
         })
         .collect()

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -123,6 +123,8 @@ pub struct LicenseInfo {
     pub is_restrictive: bool,    // A boolean indicating whether the license is restrictive or not
     pub compatibility: LicenseCompatibility, // Compatibility with project license
     pub osi_status: OsiStatus,   // OSI approval status
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sub_project: Option<String>, // Workspace member that brought in this dependency (None for non-monorepos)
 }
 
 impl LicenseInfo {
@@ -151,6 +153,10 @@ impl LicenseInfo {
 
     pub fn osi_status(&self) -> &OsiStatus {
         &self.osi_status
+    }
+
+    pub fn sub_project(&self) -> Option<&str> {
+        self.sub_project.as_deref()
     }
 
     #[allow(dead_code)]
@@ -1360,6 +1366,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: OsiStatus::Approved,
+            sub_project: None,
         };
 
         assert_eq!(info.name(), "test_package");
@@ -1378,6 +1385,7 @@ mod tests {
             is_restrictive: true,
             compatibility: LicenseCompatibility::Unknown,
             osi_status: OsiStatus::Unknown,
+            sub_project: None,
         };
 
         assert_eq!(info.get_license(), "No License");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,7 @@ use crate::languages::{
     c::analyze_c_licenses, cpp::analyze_cpp_licenses, dotnet::analyze_dotnet_licenses,
     go::analyze_go_licenses, node::analyze_js_licenses_with_no_local,
     python::analyze_python_licenses, r::analyze_r_licenses,
-    rust::analyze_rust_licenses_with_no_local,
+    rust::analyze_rust_licenses_with_metadata,
 };
 use crate::languages::{Language, CPP_PATHS, C_PATHS, DOTNET_PATHS, PYTHON_PATHS, R_PATHS};
 use crate::licenses::{
@@ -25,7 +25,7 @@ struct ProjectRoot {
 
 /// Find project files only in the root directory (not recursive)
 fn find_project_roots(root_path: impl AsRef<Path>) -> FeludaResult<Vec<ProjectRoot>> {
-    let mut project_roots = Vec::new();
+    let mut project_roots: Vec<ProjectRoot> = Vec::new();
     let root = root_path.as_ref();
 
     log(
@@ -56,6 +56,22 @@ fn find_project_roots(root_path: impl AsRef<Path>) -> FeludaResult<Vec<ProjectRo
                         project_type
                     ),
                 );
+
+                // Several markers can map to the same language (e.g. go.mod and go.work). Keep
+                // one entry per language per directory; analyzers handle workspace resolution.
+                let already_seen = project_roots.iter().any(|existing| {
+                    existing.path == root
+                        && std::mem::discriminant(&existing.project_type)
+                            == std::mem::discriminant(&project_type)
+                });
+                if already_seen {
+                    log(
+                        LogLevel::Info,
+                        &format!("Skipping duplicate language entry for: {}", path.display()),
+                    );
+                    continue;
+                }
+
                 project_roots.push(ProjectRoot {
                     path: root.to_path_buf(),
                     project_type,
@@ -396,12 +412,15 @@ fn parse_dependencies(
                             LogLevel::Info,
                             &format!("Found {} packages in Rust project", metadata.packages.len()),
                         );
+                        let workspace_size = metadata.workspace_members.len();
                         indicator.update_progress(&format!(
-                            "found {} packages",
-                            metadata.packages.len()
+                            "found {} packages ({} workspace member{})",
+                            metadata.packages.len(),
+                            workspace_size,
+                            if workspace_size == 1 { "" } else { "s" }
                         ));
 
-                        analyze_rust_licenses_with_no_local(metadata.packages, no_local)
+                        analyze_rust_licenses_with_metadata(metadata, config, no_local)
                     }
                     Err(err) => {
                         log(
@@ -434,23 +453,38 @@ fn parse_dependencies(
                 }
             }
             Language::Go(_) => {
-                let project_path = Path::new(project_path).join("go.mod");
-                log(
-                    LogLevel::Info,
-                    &format!("Parsing Go project: {}", project_path.display()),
-                );
+                let go_work_path = Path::new(project_path).join("go.work");
+                if go_work_path.exists() {
+                    log(
+                        LogLevel::Info,
+                        &format!("Parsing Go workspace: {}", go_work_path.display()),
+                    );
+                    indicator.update_progress("analyzing go.work");
 
-                indicator.update_progress("analyzing go.mod");
+                    let deps =
+                        crate::languages::go::analyze_go_workspace_licenses(project_path, config);
+                    indicator.update_progress(&format!("found {} dependencies", deps.len()));
+                    deps
+                } else {
+                    let project_path = Path::new(project_path).join("go.mod");
+                    log(
+                        LogLevel::Info,
+                        &format!("Parsing Go project: {}", project_path.display()),
+                    );
 
-                match project_path.to_str() {
-                    Some(path_str) => {
-                        let deps = analyze_go_licenses(path_str, config);
-                        indicator.update_progress(&format!("found {} dependencies", deps.len()));
-                        deps
-                    }
-                    None => {
-                        log(LogLevel::Error, "Failed to convert Go path to string");
-                        Vec::new()
+                    indicator.update_progress("analyzing go.mod");
+
+                    match project_path.to_str() {
+                        Some(path_str) => {
+                            let deps = analyze_go_licenses(path_str, config);
+                            indicator
+                                .update_progress(&format!("found {} dependencies", deps.len()));
+                            deps
+                        }
+                        None => {
+                            log(LogLevel::Error, "Failed to convert Go path to string");
+                            Vec::new()
+                        }
                     }
                 }
             }
@@ -856,5 +890,39 @@ mod tests {
         assert!(result.is_ok());
         let licenses = result.unwrap();
         assert!(licenses.is_empty());
+    }
+
+    #[test]
+    fn test_find_project_roots_dedupes_go_workspace_markers() {
+        // Both go.mod and go.work in the same directory should produce a single Go entry,
+        // not two — the analyzer decides which strategy to use.
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(root.join("go.mod"), "module example/root\n").unwrap();
+        std::fs::write(root.join("go.work"), "go 1.22\n\nuse ./svc\n").unwrap();
+
+        let result = find_project_roots(root.to_str().unwrap()).unwrap();
+        let go_count = result
+            .iter()
+            .filter(|r| {
+                std::mem::discriminant(&r.project_type)
+                    == std::mem::discriminant(&Language::Go("go.mod"))
+            })
+            .count();
+        assert_eq!(go_count, 1, "expected exactly one Go project root entry");
+    }
+
+    #[test]
+    fn test_find_project_roots_finds_go_work_alone() {
+        // A go.work without a sibling go.mod should still register a Go project root.
+        let temp = tempfile::TempDir::new().unwrap();
+        std::fs::write(temp.path().join("go.work"), "go 1.22\n\nuse ./svc\n").unwrap();
+
+        let result = find_project_roots(temp.path().to_str().unwrap()).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            std::mem::discriminant(&result[0].project_type),
+            std::mem::discriminant(&Language::Go("go.work"))
+        );
     }
 }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -286,6 +286,8 @@ fn print_verbose_table(
 ) {
     log(LogLevel::Info, "Printing verbose table");
 
+    let has_workspace = license_info.iter().any(|i| i.sub_project().is_some());
+
     let mut headers = vec![
         "Name".to_string(),
         "Version".to_string(),
@@ -300,6 +302,10 @@ fn print_verbose_table(
 
     // Always add OSI status column in verbose mode
     headers.push("OSI Status".to_string());
+
+    if has_workspace {
+        headers.push("Sub-project".to_string());
+    }
 
     let mut formatter = TableFormatter::new(headers);
 
@@ -320,6 +326,10 @@ fn print_verbose_table(
 
             // Always add OSI status in verbose mode
             row.push(info.osi_status().to_string());
+
+            if has_workspace {
+                row.push(info.sub_project().unwrap_or("-").to_string());
+            }
 
             row
         })
@@ -461,6 +471,8 @@ fn print_summary_table(
         format!("Total dependencies scanned: {total_packages}").bold()
     );
 
+    print_workspace_breakdown(license_info);
+
     if !restrictive_licenses.is_empty() {
         print_restrictive_licenses_table(&restrictive_licenses);
     } else {
@@ -480,6 +492,35 @@ fn print_summary_table(
             "\n{}\n",
             "✅ No incompatible licenses found! 🎉".green().bold()
         );
+    }
+}
+
+/// Print a breakdown of dep counts per workspace member when the scan covers a monorepo.
+/// Silent for single-project scans.
+fn print_workspace_breakdown(license_info: &[LicenseInfo]) {
+    let mut by_member: HashMap<String, usize> = HashMap::new();
+    for info in license_info {
+        if let Some(label) = info.sub_project() {
+            for member in label.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+                *by_member.entry(member.to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    if by_member.is_empty() {
+        return;
+    }
+
+    let mut entries: Vec<(String, usize)> = by_member.into_iter().collect();
+    entries.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    println!(
+        "\n{} {}",
+        "🧩".bold(),
+        "Workspace breakdown:".bold().underline()
+    );
+    for (member, count) in entries {
+        println!("  • {} {}", count.to_string().cyan().bold(), member);
     }
 }
 
@@ -1032,6 +1073,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "crate2".to_string(),
@@ -1040,6 +1082,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "crate3".to_string(),
@@ -1048,6 +1091,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "crate4".to_string(),
@@ -1056,6 +1100,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::OsiStatus::Unknown,
+                sub_project: None,
             },
         ]
     }
@@ -1069,6 +1114,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "crate2".to_string(),
@@ -1077,6 +1123,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ]
     }
@@ -1410,6 +1457,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package2".to_string(),
@@ -1418,6 +1466,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1449,6 +1498,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "bad_package".to_string(),
@@ -1457,6 +1507,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1488,6 +1539,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "restrictive_package".to_string(),
@@ -1496,6 +1548,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1526,6 +1579,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let config = ReportConfig::new(
@@ -1546,6 +1600,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let config = ReportConfig::new(
@@ -1566,6 +1621,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let config = ReportConfig::new(
@@ -1595,6 +1651,7 @@ mod tests {
             is_restrictive: true,
             compatibility: LicenseCompatibility::Incompatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let config = ReportConfig::new(
@@ -1624,6 +1681,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         output_github_format(
@@ -1642,6 +1700,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         output_jenkins_format(
@@ -1661,6 +1720,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "restrictive2".to_string(),
@@ -1669,6 +1729,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1713,5 +1774,64 @@ mod tests {
         assert!(debug_str.contains("json: true"));
         assert!(debug_str.contains("yaml: false"));
         assert!(debug_str.contains("Github"));
+    }
+
+    #[test]
+    fn test_workspace_breakdown_no_panic_on_empty() {
+        // Pure smoke test: with no sub_project entries, the breakdown printer should
+        // silently no-op rather than print or panic.
+        let data: Vec<LicenseInfo> = vec![LicenseInfo {
+            name: "foo".into(),
+            version: "1.0".into(),
+            license: Some("MIT".into()),
+            is_restrictive: false,
+            compatibility: LicenseCompatibility::Compatible,
+            osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
+        }];
+        print_workspace_breakdown(&data);
+    }
+
+    #[test]
+    fn test_workspace_breakdown_prints_per_member() {
+        // Smoke test for the workspace breakdown path; just ensure it runs without panic
+        // when sub_project values are populated, including comma-joined multi-member values.
+        let data = vec![
+            LicenseInfo {
+                name: "shared-dep".into(),
+                version: "1.0".into(),
+                license: Some("MIT".into()),
+                is_restrictive: false,
+                compatibility: LicenseCompatibility::Compatible,
+                osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: Some("api, worker".into()),
+            },
+            LicenseInfo {
+                name: "api-only".into(),
+                version: "2.0".into(),
+                license: Some("Apache-2.0".into()),
+                is_restrictive: false,
+                compatibility: LicenseCompatibility::Compatible,
+                osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: Some("api".into()),
+            },
+        ];
+        print_workspace_breakdown(&data);
+    }
+
+    #[test]
+    fn test_verbose_table_includes_subproject_column_when_set() {
+        // Verbose table renders Sub-project column conditionally on data; just exercise
+        // the rendering paths without crashing.
+        let data = vec![LicenseInfo {
+            name: "hyper".into(),
+            version: "1.0".into(),
+            license: Some("MIT".into()),
+            is_restrictive: false,
+            compatibility: LicenseCompatibility::Compatible,
+            osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: Some("api".into()),
+        }];
+        print_verbose_table(&data, false, Some("MIT"));
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1048,6 +1048,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let app = App::new(test_data.clone(), Some("MIT".to_string()));
@@ -1080,6 +1081,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package2".to_string(),
@@ -1088,6 +1090,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package3".to_string(),
@@ -1096,6 +1099,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1137,6 +1141,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let mut app = App::new(test_data, None);
@@ -1174,6 +1179,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "short".to_string(),
@@ -1182,6 +1188,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1220,6 +1227,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let (name_len, _, _, _, _, _) = constraint_len_calculator(&test_data);
@@ -1237,6 +1245,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "incompatible".to_string(),
@@ -1245,6 +1254,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "unknown".to_string(),
@@ -1253,6 +1263,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::OsiStatus::Unknown,
+                sub_project: None,
             },
         ];
 
@@ -1271,6 +1282,7 @@ mod tests {
                 is_restrictive: true, // true
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package2".to_string(),
@@ -1279,6 +1291,7 @@ mod tests {
                 is_restrictive: false, // false
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1317,6 +1330,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "much_longer_name".to_string(),
@@ -1325,6 +1339,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1347,6 +1362,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "apple".to_string(),
@@ -1355,6 +1371,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "banana".to_string(),
@@ -1363,6 +1380,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1389,6 +1407,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "zebra".to_string(),
@@ -1397,6 +1416,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1421,6 +1441,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package2".to_string(),
@@ -1429,6 +1450,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1455,6 +1477,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let mut app = App::new(test_data, None);
@@ -1483,6 +1506,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let mut app = App::new(test_data, None);
@@ -1513,6 +1537,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "apple".to_string(),
@@ -1521,6 +1546,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1549,6 +1575,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
         }];
 
         let app = App::new(test_data, None);
@@ -1569,6 +1596,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package2".to_string(),
@@ -1577,6 +1605,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package3".to_string(),
@@ -1585,6 +1614,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1612,6 +1642,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package2".to_string(),
@@ -1620,6 +1651,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package3".to_string(),
@@ -1628,6 +1660,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 
@@ -1653,6 +1686,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package2".to_string(),
@@ -1661,6 +1695,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
             LicenseInfo {
                 name: "package3".to_string(),
@@ -1669,6 +1704,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                sub_project: None,
             },
         ];
 


### PR DESCRIPTION
## Summary

Scanning at a monorepo root now produces a single unified report covering every workspace member, with each dependency attributed to the member(s) that pull it in. Previously a `feluda` run at the root of a Cargo workspace, `go.work` repo, npm/yarn/pnpm workspace, or Python uv workspace silently under-reported, since only the root manifest was parsed.

## Motivation

Feluda's parsers walked a single manifest per project root, which meant any monorepo layout with sub-package manifests had its dependencies missed entirely. For users running feluda in CI at the repo root, this produced incomplete license reports — a correctness gap, not just a UX one. This PR closes that gap for the four workspace flavors most common in the languages feluda already supports.

## Changes

Detection per ecosystem (in `src/languages/`):

- **Cargo** (`rust.rs`) — walks the resolve graph from each `metadata.workspace_members` entry. Workspace members themselves are excluded from the dep list; their transitive deps are tagged with the member name(s) that depend on them.
- **npm/yarn/pnpm** (`node.rs`) — reads each member's `package.json` (resolved via the root `workspaces` field, array or object form) and attributes every declared dep to its member.
- **Go** (`go.rs`) — parses `use` directives in `go.work`, scans each member's `go.mod`, and merges results. Adds `go.work` as a recognized project marker; `find_project_roots` dedupes Go entries when both `go.mod` and `go.work` are present.
- **Python uv** (`python.rs`) — detects `[tool.uv.workspace]` in the root `pyproject.toml`, expands the `members` glob (honoring `exclude`), and merges direct deps from each member's `pyproject.toml`. The pyproject branch is restructured so a workspace-only root (no `[project] dependencies` of its own) still produces a useful scan. Inline PEP 508 parsing was extracted into `extract_pep508_deps_from_toml` / `split_pep508_dep` so workspace member parsing reuses the same logic.

User-visible output:

- Verbose table grows a `Sub-project` column when any dep is attributed (`src/table.rs`).
- Summary mode adds a `Workspace breakdown:` section with per-member dep counts (`src/reporter.rs`).
- JSON/YAML entries gain an optional `sub_project` field. The field is omitted entirely on single-project scans, keeping the schema stable for existing consumers (`src/generate.rs`).
- `LicenseInfo` now carries `sub_project: Option<String>`. Multi-owner deps list members comma-separated.

Docs (`docs/source/`) updated to cover workspace detection, the new column, and the updated supported-languages matrix.

## Testing

- `cargo test` — full suite passes locally.
- Manually scanned mixed-ecosystem fixtures (Cargo workspace with two members, `go.work` with three modules, pnpm workspace, uv workspace with `exclude`) and verified attribution in both verbose and JSON output.
- Verified single-project scans: JSON/YAML output is unchanged byte-for-byte (no `sub_project` key emitted).

Example:

    feluda --path ./my-monorepo --json

    [
      {
        "name": "serde",
        "version": "1.0.228",
        "license": "MIT OR Apache-2.0",
        ...
        "sub_project": "ws-api, ws-worker"
      }
    ]

## Related

Refs the broader workspace-support effort tracked under `feat/workspace-support`.
