### PR TITLE
feat(sarif): add SARIF 2.1.0 output for GitHub Advanced Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,13 +515,29 @@ feluda --gui
 
 Feluda provides several options for CI integration:
 
-- `--ci-format <github|jenkins>`: Generate output compatible with the specified CI system
+- `--ci-format <github|jenkins|sarif>`: Generate output compatible with the specified CI system
 - `--fail-on-restrictive`: Make the CI build fail when restrictive licenses are found
 - `--fail-on-incompatible`: Make the CI build fail when incompatible licenses are found
 - `--osi <approved|not-approved|unknown>`: Filter by OSI license approval status
 - `--output-file <path>`: Write the output to a file instead of stdout
 
-Feluda can be easily integrated into your CI/CD pipelines with built-in support for **GitHub Actions** and **Jenkins**.
+Feluda can be easily integrated into your CI/CD pipelines with built-in support for **GitHub Actions**, **Jenkins**, and **GitHub Advanced Security** via SARIF.
+
+### GitHub Advanced Security (SARIF)
+
+Feluda emits [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) output that GitHub Advanced Security can ingest to surface license findings in the **Security** tab and in VS Code's Problems panel.
+
+```yaml
+      - name: Run Feluda license scan
+        run: feluda --ci-format sarif --output-file results.sarif
+
+      - name: Upload SARIF to GitHub Advanced Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+```
+
+Restrictive licenses are reported at `warning` level; licenses incompatible with your project license are reported at `error` level. A clean scan still produces a valid SARIF file (empty `results` array), so the upload step never needs to be skipped.
 
 ### GitHub Actions
 

--- a/docs/source/cli/output.rst
+++ b/docs/source/cli/output.rst
@@ -179,6 +179,24 @@ Feluda writes ``::error`` and ``::warning`` annotations that GitHub parses autom
 
 Feluda formats its output with Jenkins-style prefixes to improve log parsing and highlighting.
 
+**SARIF (GitHub Advanced Security / VS Code):**
+
+.. code-block:: bash
+
+   feluda --ci-format sarif --output-file results.sarif
+
+Feluda emits a `SARIF 2.1.0 <https://sarifweb.azurewebsites.net/>`_ document.
+Upload it to GitHub Advanced Security to surface findings in the Security tab and
+in VS Code's Problems panel. A clean scan still produces a valid SARIF file with an
+empty ``results`` array, so CI workflows can unconditionally upload the artifact.
+
+.. code-block:: yaml
+
+   - run: feluda --ci-format sarif --output-file results.sarif
+   - uses: github/codeql-action/upload-sarif@v3
+     with:
+       sarif_file: results.sarif
+
 **Options:**
 
 .. list-table::
@@ -190,4 +208,6 @@ Feluda formats its output with Jenkins-style prefixes to improve log parsing and
    * - ``github``
      - GitHub Actions annotation format
    * - ``jenkins``
-     - Jenkins-compatible log markers
+     - Jenkins-compatible log markers (JUnit XML)
+   * - ``sarif``
+     - SARIF 2.1.0 for GitHub Advanced Security and VS Code

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -103,9 +103,11 @@ single-line summary.
 CI/CD Integration
 ^^^^^^^^^^^^^^^^^
 
-Integrates seamlessly with **GitHub Actions** and **Jenkins** to automate
-license compliance in your pipeline. Fail builds early when problematic
-licenses are detected.
+Integrates seamlessly with **GitHub Actions**, **Jenkins**, and **GitHub Advanced
+Security** to automate license compliance in your pipeline. Fail builds early when
+problematic licenses are detected. Use ``--ci-format sarif`` to emit
+`SARIF 2.1.0 <https://sarifweb.azurewebsites.net/>`_ output for upload to GitHub
+Advanced Security code scanning or the VS Code Problems panel.
 
 Verbose Analysis
 ^^^^^^^^^^^^^^^^

--- a/docs/source/integrations/github-actions.rst
+++ b/docs/source/integrations/github-actions.rst
@@ -120,6 +120,48 @@ Full workflow with compliance artifacts and SBOM generation:
 
 ----
 
+GitHub Advanced Security (SARIF)
+---------------------------------
+
+Surface license findings directly in the repository's **Security** tab using
+`GitHub Advanced Security <https://docs.github.com/en/code-security>`_ code scanning.
+
+.. code-block:: yaml
+
+   name: Feluda SARIF Scan
+   on:
+     push:
+       branches: [ main ]
+     pull_request:
+       branches: [ main ]
+
+   jobs:
+     sarif:
+       runs-on: ubuntu-latest
+       permissions:
+         security-events: write
+       steps:
+         - uses: actions/checkout@v4
+
+         - name: Run Feluda license scan
+           run: feluda --ci-format sarif --output-file results.sarif
+
+         - name: Upload SARIF to GitHub Advanced Security
+           uses: github/codeql-action/upload-sarif@v3
+           with:
+             sarif_file: results.sarif
+
+Feluda maps **restrictive** licenses to SARIF ``warning`` level and **incompatible**
+licenses (when a project license is specified) to ``error`` level. A clean scan still
+produces a valid SARIF file with an empty ``results`` array, so the upload step never
+needs to be skipped.
+
+.. tip::
+   Pass ``--project-license MIT`` (or your actual license) to enable incompatibility
+   detection and get ``error``-level findings alongside ``warning``-level ones.
+
+----
+
 GitHub Token Configuration
 --------------------------
 

--- a/docs/source/integrations/index.rst
+++ b/docs/source/integrations/index.rst
@@ -29,8 +29,12 @@ Supported Platforms
      - Integration Method
    * - GitHub Actions
      - Official Feluda Action (``anistark/feluda@v1``)
+   * - GitHub Advanced Security
+     - ``--ci-format sarif`` → upload via ``github/codeql-action/upload-sarif``
    * - Jenkins
      - Shell commands with ``--ci-format jenkins``
+   * - VS Code Problems panel
+     - ``--ci-format sarif`` → open SARIF file with the SARIF Viewer extension
    * - GitLab CI
      - Shell commands with standard output
    * - Other CI/CD
@@ -74,8 +78,11 @@ Feluda adjusts its output to match the CI platform's annotation system.
    # GitHub Actions annotations
    feluda --ci-format github
 
-   # Jenkins log markers
+   # Jenkins log markers (JUnit XML)
    feluda --ci-format jenkins
+
+   # SARIF 2.1.0 for GitHub Advanced Security and VS Code
+   feluda --ci-format sarif --output-file results.sarif
 
 ----
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -62,9 +62,9 @@ Use this table to double-check flag behavior before scripting.
    * - ``feluda --output-file <path>``
      - Save text output to a file.
      - Works with any format flag.
-   * - ``feluda --ci-format {github|jenkins}``
+   * - ``feluda --ci-format {github|jenkins|sarif}``
      - Emit annotations suited to CI platforms.
-     - Pairs with ``--fail-on-*`` for fully automated gates.
+     - ``sarif`` emits SARIF 2.1.0 for GitHub Advanced Security; pairs with ``--fail-on-*`` for automated gates.
    * - ``feluda --debug`` / ``-d``
      - Enable debug mode with detailed logging.
      - Useful for troubleshooting detection issues.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,8 @@ pub enum CiFormat {
     Github,
     /// Jenkins compatible format (JUnit XML)
     Jenkins,
+    /// SARIF 2.1.0 format (GitHub Advanced Security, VS Code Problems panel)
+    Sarif,
 }
 
 /// SBOM format options
@@ -204,7 +206,7 @@ pub struct Cli {
     #[arg(long, short)]
     pub language: Option<String>,
 
-    /// Output format for CI systems (github, jenkins)
+    /// Output format for CI systems (github, jenkins, sarif)
     #[arg(long, value_enum)]
     pub ci_format: Option<CiFormat>,
 
@@ -346,11 +348,11 @@ impl LoadingIndicator {
         let progress = self.progress.clone();
 
         // Clear the current line and move to beginning
-        print!("\x1B[2K\r");
+        eprint!("\x1B[2K\r");
 
         // Print initial message with spinner
-        print!("{} {} ", spinner_frames[0].cyan(), message);
-        io::stdout().flush().unwrap();
+        eprint!("{} {} ", spinner_frames[0].cyan(), message);
+        io::stderr().flush().unwrap();
 
         let handle = thread::spawn(move || {
             let mut frame_idx = 0;
@@ -358,29 +360,29 @@ impl LoadingIndicator {
                 frame_idx = (frame_idx + 1) % spinner_frames.len();
 
                 // Clear the current line and move to beginning
-                print!("\x1B[2K\r");
+                eprint!("\x1B[2K\r");
 
                 // Print spinner and message
                 let spinner_char = spinner_frames[frame_idx];
-                print!("{} {} ", spinner_char.cyan(), message);
+                eprint!("{} {} ", spinner_char.cyan(), message);
 
                 // Print progress info if available
                 if let Some(ref progress_text) = *progress.lock().unwrap() {
-                    print!("({progress_text})");
+                    eprint!("({progress_text})");
                 }
 
-                io::stdout().flush().unwrap();
+                io::stderr().flush().unwrap();
                 thread::sleep(Duration::from_millis(80));
             }
 
             // Clear line and print completion message
-            print!("\x1B[2K\r");
-            print!("{} {} ", "✓".green().bold(), message);
+            eprint!("\x1B[2K\r");
+            eprint!("{} {} ", "✓".green().bold(), message);
             if let Some(ref progress_text) = *progress.lock().unwrap() {
-                print!("({progress_text})");
+                eprint!("({progress_text})");
             }
-            println!(" ✅");
-            io::stdout().flush().unwrap();
+            eprintln!(" ✅");
+            io::stderr().flush().unwrap();
         });
 
         self.handle = Some(handle);

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -215,6 +215,16 @@ pub fn generate_report(data: Vec<LicenseInfo>, config: ReportConfig) -> (bool, b
     );
     log_debug("Filtered license data", &filtered_data);
 
+    // SARIF always produces output (empty results = clean scan), so bypass the early return.
+    if matches!(config.ci_format, Some(CiFormat::Sarif)) {
+        output_sarif_format(
+            &filtered_data,
+            config.output_file.as_deref(),
+            config.project_license.as_deref(),
+        );
+        return (has_restrictive, has_incompatible);
+    }
+
     if filtered_data.is_empty() {
         println!(
             "\n{}\n",
@@ -237,6 +247,7 @@ pub fn generate_report(data: Vec<LicenseInfo>, config: ReportConfig) -> (bool, b
                 config.output_file.as_deref(),
                 config.project_license.as_deref(),
             ),
+            CiFormat::Sarif => unreachable!("handled above"),
         }
     } else if config.json {
         // JSON output
@@ -974,6 +985,142 @@ fn output_jenkins_format(
     }
 }
 
+fn output_sarif_format(
+    license_info: &[LicenseInfo],
+    output_path: Option<&str>,
+    project_license: Option<&str>,
+) {
+    log(LogLevel::Info, "Generating SARIF 2.1.0 output");
+
+    let version = env!("CARGO_PKG_VERSION");
+
+    let mut rules = vec![serde_json::json!({
+        "id": "feluda/restrictive-license",
+        "name": "RestrictiveLicense",
+        "shortDescription": { "text": "Dependency has a restrictive license" },
+        "fullDescription": {
+            "text": "This dependency uses a license that may impose restrictions on how the software can be used, modified, or distributed."
+        },
+        "helpUri": "https://github.com/anistark/feluda",
+        "defaultConfiguration": { "level": "warning" }
+    })];
+
+    if project_license.is_some() {
+        rules.push(serde_json::json!({
+            "id": "feluda/incompatible-license",
+            "name": "IncompatibleLicense",
+            "shortDescription": { "text": "Dependency license is incompatible with the project license" },
+            "fullDescription": {
+                "text": "This dependency's license may be incompatible with your project's license, potentially creating legal issues."
+            },
+            "helpUri": "https://github.com/anistark/feluda",
+            "defaultConfiguration": { "level": "error" }
+        }));
+    }
+
+    let mut results: Vec<serde_json::Value> = Vec::new();
+
+    for info in license_info {
+        if *info.is_restrictive() {
+            results.push(serde_json::json!({
+                "ruleId": "feluda/restrictive-license",
+                "level": "warning",
+                "message": {
+                    "text": format!(
+                        "Dependency '{}@{}' has restrictive license: {}",
+                        info.name(), info.version(), info.get_license()
+                    )
+                },
+                "locations": []
+            }));
+
+            log(
+                LogLevel::Info,
+                &format!(
+                    "Added SARIF warning for restrictive license: {}",
+                    info.name()
+                ),
+            );
+        }
+
+        if let Some(proj_license) = project_license {
+            if info.compatibility == LicenseCompatibility::Incompatible {
+                results.push(serde_json::json!({
+                    "ruleId": "feluda/incompatible-license",
+                    "level": "error",
+                    "message": {
+                        "text": format!(
+                            "Dependency '{}@{}' has license {} which is incompatible with project license {}",
+                            info.name(), info.version(), info.get_license(), proj_license
+                        )
+                    },
+                    "locations": []
+                }));
+
+                log(
+                    LogLevel::Info,
+                    &format!(
+                        "Added SARIF error for incompatible license: {}",
+                        info.name()
+                    ),
+                );
+            }
+        }
+    }
+
+    log(
+        LogLevel::Info,
+        &format!(
+            "SARIF: {} rule(s), {} result(s)",
+            rules.len(),
+            results.len()
+        ),
+    );
+
+    let sarif = serde_json::json!({
+        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "feluda",
+                    "version": version,
+                    "informationUri": "https://github.com/anistark/feluda",
+                    "rules": rules
+                }
+            },
+            "results": results
+        }]
+    });
+
+    let output = match serde_json::to_string_pretty(&sarif) {
+        Ok(s) => s,
+        Err(err) => {
+            log_error("Failed to serialize SARIF output", &err);
+            println!("Error: Failed to generate SARIF output");
+            return;
+        }
+    };
+
+    if let Some(path) = output_path {
+        log(
+            LogLevel::Info,
+            &format!("Writing SARIF output to file: {path}"),
+        );
+        match fs::write(path, &output) {
+            Ok(_) => println!("SARIF output written to: {path}"),
+            Err(err) => {
+                log_error(&format!("Failed to write SARIF output file: {path}"), &err);
+                println!("Error: Failed to write SARIF output file");
+                println!("{output}");
+            }
+        }
+    } else {
+        log(LogLevel::Info, "Writing SARIF output to stdout");
+        println!("{output}");
+    }
+}
+
 // Add gist report function to reporter.rs
 fn print_gist_summary(
     license_info: &[LicenseInfo],
@@ -1670,6 +1817,147 @@ mod tests {
         let (has_restrictive, has_incompatible) = generate_report(data, config);
         assert!(has_restrictive);
         assert!(has_incompatible);
+    }
+
+    #[test]
+    fn test_sarif_output_format_to_file() {
+        let data = get_test_data();
+        let temp_dir = setup();
+        let output_path = temp_dir.path().join("results.sarif");
+        let config = ReportConfig::new(
+            false,
+            false,
+            false,
+            false,
+            false,
+            Some(CiFormat::Sarif),
+            Some(output_path.to_str().unwrap().to_string()),
+            Some("MIT".to_string()),
+            false,
+            None,
+        );
+
+        let result = generate_report(data, config);
+        assert_eq!(result, (true, true));
+
+        let content = fs::read_to_string(&output_path).expect("Failed to read SARIF output file");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&content).expect("SARIF output is not valid JSON");
+
+        assert_eq!(parsed["version"], "2.1.0");
+        assert!(parsed["$schema"].as_str().unwrap().contains("sarif-schema"));
+        let runs = parsed["runs"].as_array().unwrap();
+        assert_eq!(runs.len(), 1);
+        let driver = &runs[0]["tool"]["driver"];
+        assert_eq!(driver["name"], "feluda");
+        let results = runs[0]["results"].as_array().unwrap();
+        assert!(!results.is_empty());
+
+        let rule_ids: Vec<&str> = results
+            .iter()
+            .map(|r| r["ruleId"].as_str().unwrap())
+            .collect();
+        assert!(rule_ids.contains(&"feluda/restrictive-license"));
+        assert!(rule_ids.contains(&"feluda/incompatible-license"));
+    }
+
+    #[test]
+    fn test_sarif_output_clean_scan() {
+        let data = vec![LicenseInfo {
+            name: "clean-pkg".to_string(),
+            version: "1.0.0".to_string(),
+            license: Some("MIT".to_string()),
+            is_restrictive: false,
+            compatibility: LicenseCompatibility::Compatible,
+            osi_status: crate::licenses::OsiStatus::Approved,
+            sub_project: None,
+        }];
+        let temp_dir = setup();
+        let output_path = temp_dir.path().join("clean.sarif");
+        let config = ReportConfig::new(
+            false,
+            false,
+            false,
+            false,
+            false,
+            Some(CiFormat::Sarif),
+            Some(output_path.to_str().unwrap().to_string()),
+            Some("MIT".to_string()),
+            false,
+            None,
+        );
+
+        let (has_restrictive, has_incompatible) = generate_report(data, config);
+        assert!(!has_restrictive);
+        assert!(!has_incompatible);
+
+        let content = fs::read_to_string(&output_path).expect("Failed to read SARIF output");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&content).expect("SARIF output is not valid JSON");
+
+        assert_eq!(parsed["version"], "2.1.0");
+        let results = parsed["runs"][0]["results"].as_array().unwrap();
+        assert!(
+            results.is_empty(),
+            "Clean scan should produce zero SARIF results"
+        );
+    }
+
+    #[test]
+    fn test_sarif_output_stdout() {
+        let data = get_test_data();
+        let config = ReportConfig::new(
+            false,
+            false,
+            false,
+            false,
+            false,
+            Some(CiFormat::Sarif),
+            None,
+            Some("MIT".to_string()),
+            false,
+            None,
+        );
+        let (has_restrictive, has_incompatible) = generate_report(data, config);
+        assert!(has_restrictive);
+        assert!(has_incompatible);
+    }
+
+    #[test]
+    fn test_sarif_output_no_project_license() {
+        let data = get_test_data();
+        let temp_dir = setup();
+        let output_path = temp_dir.path().join("no_proj.sarif");
+        let config = ReportConfig::new(
+            false,
+            false,
+            false,
+            false,
+            false,
+            Some(CiFormat::Sarif),
+            Some(output_path.to_str().unwrap().to_string()),
+            None,
+            false,
+            None,
+        );
+
+        let (has_restrictive, _) = generate_report(data, config);
+        assert!(has_restrictive);
+
+        let content = fs::read_to_string(&output_path).expect("Failed to read SARIF output");
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let rules = parsed["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap();
+        let rule_ids: Vec<&str> = rules.iter().map(|r| r["id"].as_str().unwrap()).collect();
+        // Without a project license, incompatible-license rule should not be emitted
+        assert!(!rule_ids.contains(&"feluda/incompatible-license"));
+        assert!(rule_ids.contains(&"feluda/restrictive-license"));
+
+        let results = parsed["runs"][0]["results"].as_array().unwrap();
+        assert!(results
+            .iter()
+            .all(|r| r["ruleId"] != "feluda/incompatible-license"));
     }
 
     #[test]


### PR DESCRIPTION
Add `--ci-format sarif` to emit a [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) document compatible with GitHub Advanced Security code scanning and the VS Code Problems panel. Restrictive licenses map to `warning`-level results; incompatible licenses (when a project license is detected or declared) map to `error`-level results. A clean scan still emits a valid SARIF file with an empty `results` array, so CI upload steps never need to be conditional.

    feluda --ci-format sarif --output-file results.sarif

    # GitHub Actions
    - run: feluda --ci-format sarif --output-file results.sarif
    - uses: github/codeql-action/upload-sarif@v3 with: sarif_file: results.sarif

Also moves spinner output from stdout to stderr so that any format written to stdout — SARIF, JSON, YAML — is clean and pipeable without stripping ANSI escape sequences.

Docs updated across CLI output reference, features page, integrations index, GitHub Actions guide, and README.

Refer to [SARIF Specs](https://github.com/oasis-tcs/sarif-spec/blob/main/sarif-2.1/schema/sarif-schema-2.1.0.json) for details 