### PR TITLE
feat(skill): add feluda Claude Code skill for inline license compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ target
 .vscode
 *.json
 !docs/source/_static/field-reports.json
+!skills/feluda/.claude-plugin/plugin.json
 *.bak
 docs/build
 docs/_build
 plan/
+.claude
+.pi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Feluda is a single Rust binary with a Sphinx documentation site:
 | **Documentation** | Sphinx (RST) | `docs/` | User-facing documentation |
 | **Examples** | Multi-language | `examples/` | Test projects for each supported language |
 | **GitHub Action** | YAML | `action.yml` | CI/CD integration for GitHub |
+| **Claude Code Skill** | Markdown | `skills/feluda/SKILL.md` | Publishable skill for license checks in any project |
 
 ### Source Layout (`src/`)
 
@@ -374,6 +375,7 @@ feluda --debug                            # Enable debug logging
 | `action.yml` | GitHub Action definition |
 | `justfile` | All development task commands |
 | `.feluda.toml` | User configuration (restrictive overrides, ignores) |
+| `skills/feluda/SKILL.md` | Claude Code skill — install in any project to get auto license checks |
 
 ---
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -129,6 +129,7 @@ Have a session to share? `Open a PR <https://github.com/anistark/feluda/edit/mai
    integrations/index
    integrations/github-actions
    integrations/jenkins
+   integrations/claude-code
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/integrations/claude-code.rst
+++ b/docs/source/integrations/claude-code.rst
@@ -1,0 +1,243 @@
+:description: Use the Feluda Claude Code skill for inline license compliance while coding.
+
+.. _claude-code:
+
+Claude Code
+===========
+
+.. rst-class:: lead
+
+   The Feluda Claude Code skill watches your dependency changes in real time and surfaces license warnings before a single line gets committed.
+
+----
+
+Overview
+--------
+
+The Feluda skill integrates directly into `Claude Code <https://claude.ai/code>`_, Anthropic's AI coding assistant. Once installed, Claude automatically runs ``feluda`` whenever it detects changes to a dependency manifest — flagging GPL, AGPL, SSPL, and other restrictive licenses inline in your session, before you commit.
+
+It also responds to natural-language requests: "check my licenses", "is this package safe to use?", or "audit my dependencies".
+
+----
+
+Installation
+------------
+
+The skill is published on the `AgentHub marketplace <https://github.com/nullorder/agenthub>`_.
+
+**Install from AgentHub (recommended):**
+
+.. code-block:: text
+
+   /plugin install feluda@agenthub
+
+**Install directly from source:**
+
+.. code-block:: text
+
+   /plugin install git+https://github.com/anistark/feluda?path=skills/feluda
+
+After installing, Claude Code loads the skill automatically — no restart needed.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+The skill requires the ``feluda`` CLI on your ``PATH``. Install it once:
+
+.. code-block:: bash
+
+   # via Rust (any OS)
+   cargo install feluda
+
+   # via Homebrew (macOS / Linux)
+   brew install feluda
+
+Binaries for Linux, macOS, and Windows are also available on the
+`GitHub Releases <https://github.com/anistark/feluda/releases>`_ page.
+
+----
+
+Usage
+-----
+
+Automatic triggering
+^^^^^^^^^^^^^^^^^^^^
+
+The skill activates automatically when Claude Code sees a dependency manifest in the
+current diff or staged changes. Supported files include:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Ecosystem
+     - Files
+   * - Rust
+     - ``Cargo.toml``, ``Cargo.lock``
+   * - Node.js
+     - ``package.json``, ``package-lock.json``, ``yarn.lock``, ``pnpm-lock.yaml``, ``bun.lockb``
+   * - Go
+     - ``go.mod``, ``go.sum``
+   * - Python
+     - ``requirements.txt``, ``pyproject.toml``, ``Pipfile.lock``, ``pip_freeze.txt``
+   * - Java
+     - ``pom.xml``, ``build.gradle``, ``build.gradle.kts``
+   * - .NET
+     - ``*.csproj``, ``*.fsproj``, ``*.vbproj``, ``*.slnx``
+   * - Ruby
+     - ``Gemfile``, ``Gemfile.lock``
+   * - PHP
+     - ``composer.json``, ``composer.lock``
+   * - C / C++
+     - ``vcpkg.json``, ``conanfile.txt``, ``CMakeLists.txt``
+   * - R
+     - ``DESCRIPTION``, ``renv.lock``
+
+Manual invocation
+^^^^^^^^^^^^^^^^^
+
+Trigger the skill explicitly with the slash command:
+
+.. code-block:: text
+
+   /feluda
+
+Or ask naturally inside any Claude Code session:
+
+.. code-block:: text
+
+   Check my licenses before I commit
+   Is this npm package safe to use?
+   Audit my dependencies
+   Does this project have any GPL dependencies?
+
+----
+
+Scan Options
+------------
+
+The skill passes flags to ``feluda`` based on context. You can also ask for a
+specific scan mode:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Ask Claude / intent
+     - Underlying command
+   * - Default pre-commit check
+     - ``feluda --restrictive``
+   * - Full audit of all licenses
+     - ``feluda --verbose``
+   * - Only incompatible licenses
+     - ``feluda --incompatible``
+   * - Check against a specific license
+     - ``feluda --project-license MIT``
+   * - Scan a subdirectory (monorepo)
+     - ``feluda --path ./packages/my-lib``
+   * - Machine-readable output
+     - ``feluda --json``
+
+For a complete reference of all CLI flags see :doc:`/cli/scan` and :doc:`/cli/filter`.
+
+----
+
+Reading the Results
+-------------------
+
+**No issues found:**
+
+The skill confirms the scan passed and continues without interruption.
+
+**Restrictive licenses found:**
+
+Claude surfaces a summary table with the flagged packages, their license identifiers,
+and why each is a concern:
+
+.. code-block:: text
+
+   ⚠ feluda found license issues:
+
+   Package           License    Why it matters
+   ──────────────────────────────────────────────────────────────────
+   some-lib@1.2.0    GPL-3.0    Copyleft — distribution requires source disclosure
+   other-lib@3.0.0   AGPL-3.0   Network copyleft — SaaS use triggers source requirement
+
+   Options:
+   1. Find an MIT/Apache-2.0 alternative
+   2. Add to .feluda.toml under [licenses] ignore = [...] if intentional
+   3. Run `feluda --verbose` for full compatibility details
+
+**Unknown licenses:**
+
+When feluda cannot resolve a license (usually due to GitHub API rate limits), Claude
+suggests setting a ``GITHUB_TOKEN`` in the environment to increase the limit from
+60 to 5,000 requests per hour.
+
+----
+
+Pre-commit Enforcement
+----------------------
+
+To enforce compliance on every ``git commit`` — not just inside Claude Code — run:
+
+.. code-block:: bash
+
+   feluda init
+
+This generates a ``.feluda.toml`` project config and adds a ``feluda`` hook to
+``.pre-commit-config.yaml``. After activation:
+
+.. code-block:: bash
+
+   pre-commit install
+
+Every ``git commit`` will now run ``feluda --fail-on-restrictive`` automatically,
+refusing the commit if restrictive licenses are present.
+
+See :doc:`/cli/scan` for the full list of ``feluda init`` options.
+
+----
+
+Configuration
+-------------
+
+Create a ``.feluda.toml`` in your project root to customise the skill's behaviour:
+
+.. code-block:: toml
+
+   [licenses]
+   project = "MIT"          # your project's own license
+   ignore = ["BSD-2-Clause"] # mark specific licenses as acceptable
+
+   [packages]
+   ignore = ["some-dual-licensed-lib"] # skip specific packages
+
+When a ``.feluda.toml`` is present, the skill respects it automatically — no extra
+flags needed.
+
+Full configuration reference: :doc:`/configuration`.
+
+----
+
+GitHub Token
+------------
+
+For projects with many dependencies, set a ``GITHUB_TOKEN`` to raise the API rate
+limit from 60 to 5,000 requests per hour:
+
+.. code-block:: bash
+
+   export GITHUB_TOKEN=ghp_...
+
+Or add it to ``.feluda.toml``:
+
+.. code-block:: toml
+
+   [api]
+   github_token = "ghp_..."
+
+.. warning::
+
+   Never commit a ``.feluda.toml`` containing a real token. Use an environment
+   variable or a secrets manager instead.

--- a/docs/source/integrations/index.rst
+++ b/docs/source/integrations/index.rst
@@ -33,6 +33,8 @@ Supported Platforms
      - ``--ci-format sarif`` → upload via ``github/codeql-action/upload-sarif``
    * - Jenkins
      - Shell commands with ``--ci-format jenkins``
+   * - Claude Code
+     - ``feluda`` skill via AgentHub — auto-runs on dep changes, inline warnings
    * - VS Code Problems panel
      - ``--ci-format sarif`` → open SARIF file with the SARIF Viewer extension
    * - GitLab CI
@@ -53,6 +55,12 @@ Quick Start
      with:
        fail-on-restrictive: true
        fail-on-incompatible: true
+
+**Claude Code:**
+
+.. code-block:: text
+
+   /plugin install feluda@agenthub
 
 **Jenkins:**
 

--- a/skills/feluda/.claude-plugin/plugin.json
+++ b/skills/feluda/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "feluda",
+  "description": "License compliance skill for Claude Code. Automatically runs feluda before committing new dependencies and surfaces restrictive license warnings (GPL, AGPL, SSPL, etc.) inline.",
+  "author": {
+    "name": "Kumar Anirudha",
+    "email": "anirudhastark@gmail.com"
+  }
+}

--- a/skills/feluda/LICENSE
+++ b/skills/feluda/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2025 Kumar Anirudha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/skills/feluda/README.md
+++ b/skills/feluda/README.md
@@ -1,0 +1,69 @@
+# feluda — Claude Code Skill
+
+A [Claude Code](https://claude.ai/code) skill that runs [feluda](https://github.com/anistark/feluda) license compliance checks automatically before you commit new dependencies, surfacing GPL, AGPL, and other restrictive licenses inline.
+
+## What it does
+
+- Detects when dependency manifests change (`Cargo.toml`, `package.json`, `go.mod`, `requirements.txt`, `pom.xml`, and more)
+- Runs `feluda --restrictive` to identify licenses that may cause legal or compliance issues
+- Surfaces results directly in your Claude Code session with clear remediation options
+- Suggests setting up `feluda init` for automatic pre-commit enforcement
+
+## Install
+
+```sh
+/plugin install feluda@agenthub
+```
+
+Or install from source:
+
+```sh
+/plugin install git+https://github.com/anistark/feluda?path=skills/feluda
+```
+
+## Prerequisites
+
+The skill requires the `feluda` CLI to be installed on your system:
+
+```sh
+cargo install feluda       # via Rust
+brew install feluda         # via Homebrew (macOS/Linux)
+```
+
+Binaries are also available at [GitHub Releases](https://github.com/anistark/feluda/releases).
+
+## Usage
+
+Claude Code invokes this skill automatically when it detects dependency file changes in a diff or staged commit. You can also trigger it explicitly:
+
+```
+/feluda
+```
+
+Or ask naturally:
+
+- "Check my licenses before I commit"
+- "Is this npm package safe to use?"
+- "Audit my dependencies"
+
+## Supported ecosystems
+
+Rust · Node.js · Go · Python · Java (Maven/Gradle) · .NET · Ruby · PHP · C/C++ · R
+
+## Configuration
+
+Create a `.feluda.toml` in your project root to customise behaviour — set your project license, mark certain licenses as acceptable, or ignore specific packages:
+
+```toml
+[licenses]
+project = "MIT"
+ignore = ["BSD-2-Clause"]
+```
+
+Run `feluda init` to generate a starter config with pre-commit hook integration.
+
+## Links
+
+- [feluda on GitHub](https://github.com/anistark/feluda)
+- [feluda on crates.io](https://crates.io/crates/feluda)
+- [Documentation](https://feluda.readthedocs.io)

--- a/skills/feluda/SKILL.md
+++ b/skills/feluda/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: feluda
+description: >
+  License compliance check with feluda. Proactively invoke this skill whenever:
+  (1) a dependency manifest is added or modified in the diff — Cargo.toml,
+  package.json, go.mod, requirements.txt, pyproject.toml, pom.xml, build.gradle,
+  Gemfile, composer.json, or similar; (2) the user is about to commit or push and
+  dependency files appear in the staged changes; (3) the user asks to "check
+  licenses", "audit dependencies", "is X license safe to use", or "will this dep
+  cause legal issues"; (4) the user adds a new package via cargo add, npm install,
+  pip install, go get, etc. Always run this before confirming a commit that
+  introduces new third-party dependencies.
+allowed-tools: Bash Glob Grep Read
+---
+
+# Feluda: License Compliance Skill
+
+[Feluda](https://github.com/anistark/feluda) is a fast, local dependency license
+scanner that flags GPL, AGPL, and other restrictive or incompatible licenses before
+they land in a commit. This skill runs it automatically and surfaces results inline.
+
+---
+
+## Step 1 — Verify feluda is installed
+
+```bash
+feluda --version 2>/dev/null || echo "FELUDA_NOT_INSTALLED"
+```
+
+If the output contains `FELUDA_NOT_INSTALLED`, stop and tell the user:
+
+> **feluda is not installed.** Install it with one of:
+>
+> ```sh
+> cargo install feluda          # via Rust (any OS)
+> brew install feluda            # via Homebrew (macOS/Linux)
+> ```
+>
+> Or download a binary from https://github.com/anistark/feluda/releases
+>
+> Once installed, re-run this check.
+
+---
+
+## Step 2 — Identify changed dependency files
+
+Run in parallel to see what changed:
+
+```bash
+git diff --cached --name-only 2>/dev/null
+git diff HEAD --name-only 2>/dev/null
+```
+
+Trigger a full feluda scan if any of these appear:
+
+| Ecosystem | Files |
+|-----------|-------|
+| Rust | `Cargo.toml`, `Cargo.lock` |
+| Node.js | `package.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb` |
+| Go | `go.mod`, `go.sum` |
+| Python | `requirements.txt`, `pyproject.toml`, `Pipfile.lock`, `pip_freeze.txt` |
+| Java | `pom.xml`, `build.gradle`, `build.gradle.kts` |
+| .NET | `*.csproj`, `*.fsproj`, `*.vbproj`, `*.slnx` |
+| Ruby | `Gemfile`, `Gemfile.lock` |
+| PHP | `composer.json`, `composer.lock` |
+| C/C++ | `vcpkg.json`, `conanfile.txt`, `CMakeLists.txt` |
+| R | `DESCRIPTION`, `renv.lock` |
+
+If the user explicitly asked for a license check, skip this step and go straight to
+Step 3 regardless of the diff.
+
+If no dependency files appear in the diff and the user has not explicitly asked, say:
+
+> No dependency changes detected in the current diff. Skipping feluda scan.
+> Run `feluda` manually for a full project scan.
+
+---
+
+## Step 3 — Run feluda
+
+Run from the project root. Start with the focused scan:
+
+```bash
+feluda --restrictive 2>&1; echo "FELUDA_EXIT:$?"
+```
+
+`--restrictive` filters to only licenses that are likely to cause issues (GPL, AGPL,
+SSPL, BUSL, CC-BY-NC, etc.) — the most actionable output for a pre-commit check.
+
+For a full scan of all dependencies and licenses (when the user asks for a complete
+audit), run:
+
+```bash
+feluda --verbose 2>&1
+```
+
+If the project has a `.feluda.toml`, feluda reads it automatically — no extra
+flags needed for configured restrictions or ignores.
+
+For monorepos or specific subdirectories:
+
+```bash
+feluda --path ./packages/my-lib --restrictive 2>&1; echo "FELUDA_EXIT:$?"
+```
+
+---
+
+## Step 4 — Interpret and surface the results
+
+Parse the exit code from `FELUDA_EXIT:N`.
+
+### Exit 0 — all clear
+
+> ✓ feluda: no restrictive licenses found.
+
+If the output mentions dependencies with **unknown** licenses, add:
+
+> Note: some dependencies have unresolved licenses. Set `GITHUB_TOKEN` in your
+> environment for higher API rate limits, which helps feluda resolve more unknowns.
+
+### Exit 1 — restrictive or incompatible licenses found
+
+Extract the flagged packages from the output and present them clearly:
+
+> ⚠ feluda found license issues in the current dependencies:
+>
+> | Package | License | Why it matters |
+> |---------|---------|----------------|
+> | `some-lib@1.2.0` | GPL-3.0 | Copyleft — any distribution requires source disclosure |
+> | `other-lib@3.0.0` | AGPL-3.0 | Network copyleft — source disclosure required even for SaaS |
+>
+> **Options before committing:**
+> 1. Find a MIT/Apache-2.0 alternative for the flagged packages.
+> 2. If the dep is intentional, add it to `.feluda.toml`:
+>    ```toml
+>    [licenses]
+>    ignore = ["GPL-3.0"]
+>    ```
+> 3. Run `feluda --verbose` for full compatibility details and OSI status.
+
+---
+
+## Step 5 — Pre-commit hook guidance
+
+If this is the first time a license issue has been found in this project, suggest
+setting up automatic enforcement:
+
+> To catch license issues automatically before every commit, run:
+>
+> ```sh
+> feluda init
+> ```
+>
+> This creates `.feluda.toml` (project config) and adds a `feluda` hook to
+> `.pre-commit-config.yaml`. After that, `git commit` will refuse if restrictive
+> licenses are present.
+
+---
+
+## Quick reference
+
+```sh
+feluda                           # Full scan, all licenses
+feluda --restrictive             # Only restrictive licenses (pre-commit focus)
+feluda --incompatible            # Only licenses incompatible with your project
+feluda --project-license MIT     # Check compatibility against a specific license
+feluda --fail-on-restrictive     # Exit 1 if any restrictive found (CI gate)
+feluda --json                    # Machine-readable JSON output
+feluda --verbose                 # OSI status, compatibility matrix, full details
+feluda --path ./sub/dir          # Scan a specific subdirectory
+feluda generate                  # Generate NOTICE / THIRD_PARTY_LICENSES file
+feluda sbom                      # Generate SPDX or CycloneDX SBOM
+feluda init                      # Set up .feluda.toml + pre-commit hook
+feluda cache --clear             # Clear the GitHub license data cache
+```


### PR DESCRIPTION
Publishes a Claude Code skill that watches dependency manifests for changes and automatically runs feluda, surfacing GPL, AGPL, SSPL, and other restrictive license warnings inline before a commit lands.

Install from AgentHub:

    /plugin install feluda@agenthub

The skill activates automatically when `Cargo.toml`, `package.json`, `go.mod`, `requirements.txt`, or similar manifests appear in the diff. It can also be triggered explicitly with `/feluda` or via natural language: "check my licenses", "audit my dependencies".

Includes a full integration guide in the docs covering installation, scan options, result interpretation, pre-commit enforcement via `feluda init`, and `.feluda.toml` configuration.