### PR TITLE
feat(watch): add `feluda watch` for continuous license scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "ignore",
  "libc",
  "mockall",
+ "notify",
  "owo-colors",
  "quick-xml",
  "ratatui",
@@ -891,6 +892,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1405,6 +1415,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1559,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -1798,6 +1848,33 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tempfile = "3.27"
 dirs = "6.0"
 semver = "1.0"
 quick-xml = { version = "0.37", features = ["serialize"] }
+notify = "8.2.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -278,6 +278,50 @@ feluda cache --clear
 - Cache is automatically loaded on subsequent analysis runs
 - Reduces GitHub API calls and improves analysis speed
 
+### Watch Mode
+
+Continuously re-scan your project whenever a dependency file changes. Feluda watches the project tree for filesystem events and re-runs the license check automatically — handy while adding or upgrading dependencies, especially with AI coding tools that pull in packages on the fly.
+
+```sh
+# Watch the current directory and re-scan on dependency changes
+feluda watch
+
+# Watch a specific path
+feluda watch --path /path/to/project/
+
+# Adjust the debounce window (ms to wait after a change before re-scanning)
+feluda watch --debounce 800
+```
+
+Watch mode reuses the same flags as a normal scan — pass them before the `watch` subcommand:
+
+```sh
+# Watch and report only restrictive licenses, as JSON
+feluda --restrictive --json watch
+
+# Watch in strict mode against a specific project license
+feluda --strict --project-license MIT watch
+```
+
+**What it watches:** every dependency manifest and lockfile Feluda understands (`Cargo.toml`/`Cargo.lock`, `package.json`/`package-lock.json`/`yarn.lock`/`pnpm-lock.yaml`, `go.mod`/`go.sum`, `pyproject.toml`/`requirements.txt`/`uv.lock`, `pom.xml`/`build.gradle`, `*.csproj`, and more), discovered recursively while honouring `.gitignore` and skipping vendored directories like `node_modules/` and `target/`.
+
+> **Note:** Watch mode is report-only — it does not support the interactive TUI (`--gui`) or remote repositories (`--repo`). Press `Ctrl-C` to stop.
+
+#### Scheduled & looped scanning
+
+When a long-running watcher isn't a good fit (CI, network filesystems, periodic audits), run Feluda's single-shot scan on a timer instead. Add `--fail-on-restrictive` (or `--fail-on-incompatible`) so the exit code gates your pipeline:
+
+```sh
+# cron — scan every 30 minutes and fail if a restrictive license appears
+*/30 * * * * cd /path/to/project && feluda --fail-on-restrictive
+
+# Claude Code /loop — re-run the check every 30 minutes
+/loop 30m feluda --restrictive
+
+# CI gate — non-zero exit stops the build
+feluda --fail-on-restrictive --json
+```
+
 ### GitHub API Authentication
 
 Feluda uses the GitHub API to fetch license information. Unauthenticated requests are limited to 60 requests/hour, which may be insufficient for large projects or frequent scans.

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -24,6 +24,8 @@ Command Overview
      - Description
    * - ``feluda``
      - Scan dependencies and detect licenses
+   * - ``feluda watch``
+     - Continuously re-scan when dependency files change
    * - ``feluda cache``
      - View and manage the license cache
    * - ``feluda generate``

--- a/docs/source/cli/watch.rst
+++ b/docs/source/cli/watch.rst
@@ -1,0 +1,118 @@
+:description: Feluda watch command for continuous license scanning.
+
+.. _cli-watch:
+
+watch
+=====
+
+.. rst-class:: lead
+
+   Keep Feluda on the case continuously — re-scan automatically whenever a dependency file changes.
+
+----
+
+Overview
+--------
+
+``feluda watch`` monitors your project tree for filesystem changes and re-runs the
+license scan whenever a dependency manifest or lockfile is added, modified, or
+removed. It is handy while adding or upgrading dependencies — especially with AI
+coding tools that pull in packages on the fly — so license issues surface the
+moment they appear.
+
+Watch mode is **report-only**: it prints the same report as a normal scan on every
+change and keeps running until interrupted with ``Ctrl-C``.
+
+----
+
+Basic Usage
+-----------
+
+.. code-block:: bash
+
+   # Watch the current directory
+   feluda watch
+
+   # Watch a specific path
+   feluda watch --path /path/to/project/
+
+   # Adjust the debounce window (milliseconds)
+   feluda watch --debounce 800
+
+**Options:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Flag
+     - Description
+   * - ``--path``, ``-p``
+     - Project directory to watch (default: ``./``)
+   * - ``--debounce``
+     - Milliseconds to wait after a change before re-scanning (default: ``500``)
+
+----
+
+Reusing Scan Flags
+------------------
+
+Watch mode inherits the same output and filter flags as a normal scan. Pass them
+**before** the ``watch`` subcommand:
+
+.. code-block:: bash
+
+   # Watch and report only restrictive licenses, as JSON
+   feluda --restrictive --json watch
+
+   # Watch in strict mode against a specific project license
+   feluda --strict --project-license MIT watch
+
+----
+
+What Feluda Watches
+-------------------
+
+Feluda recursively discovers every dependency manifest and lockfile it understands,
+honouring ``.gitignore``/``.ignore`` and skipping vendored directories such as
+``node_modules/``, ``target/``, ``vendor/``, and ``.git/``.
+
+This is the same set of files the scanner recognises, including:
+
+- **Rust** — ``Cargo.toml``, ``Cargo.lock``
+- **Node.js** — ``package.json``, ``package-lock.json``, ``yarn.lock``, ``pnpm-lock.yaml``
+- **Go** — ``go.mod``, ``go.work``, ``go.sum``, ``go.work.sum``
+- **Python** — ``pyproject.toml``, ``requirements.txt``, ``Pipfile.lock``, ``uv.lock``
+- **Java** — ``pom.xml``, ``build.gradle``, ``build.gradle.kts``
+- **.NET** — ``*.csproj``, ``*.fsproj``, ``*.vbproj``, ``*.slnx``, ``packages.lock.json``
+- **C/C++** — ``vcpkg.json``, ``conanfile.txt``, ``CMakeLists.txt``, ``MODULE.bazel``
+- **R** — ``DESCRIPTION``, ``renv.lock``
+
+.. note::
+   Watch mode does not support the interactive TUI (``--gui``) or remote
+   repositories (``--repo``). Use a local path and a non-interactive report.
+
+----
+
+Scheduled & Looped Scanning
+---------------------------
+
+When a long-running watcher isn't a good fit — CI runners, network filesystems, or
+periodic compliance audits — run Feluda's single-shot scan on a schedule instead.
+Combine it with ``--fail-on-restrictive`` (or ``--fail-on-incompatible``) so the
+exit code gates your pipeline.
+
+.. code-block:: bash
+
+   # cron — scan every 30 minutes, fail on a restrictive license
+   */30 * * * * cd /path/to/project && feluda --fail-on-restrictive
+
+   # Claude Code /loop — re-run the check every 30 minutes
+   /loop 30m feluda --restrictive
+
+   # CI gate — non-zero exit stops the build
+   feluda --fail-on-restrictive --json
+
+.. tip::
+   Use ``feluda watch`` for fast feedback during local development, and the
+   scheduled single-shot scan above for unattended or CI environments.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -106,6 +106,7 @@ Have a session to share? `Open a PR <https://github.com/anistark/feluda/edit/mai
 
    cli/index
    cli/scan
+   cli/watch
    cli/filter
    cli/cache
    cli/generate

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -50,6 +50,9 @@ Use this table to double-check flag behavior before scripting.
    * - ``feluda --github-token <token>``
      - Pass a GitHub token inline.
      - Overridden by ``GITHUB_TOKEN`` env var when both are present.
+   * - ``feluda watch``
+     - Re-scan continuously when dependency files change.
+     - Report-only; accepts ``--path`` and ``--debounce``. See :ref:`cli-watch`.
    * - ``feluda cache`` / ``feluda cache --clear``
      - Inspect or delete the GitHub license cache.
      - Default cache path: ``.feluda/cache/github_licenses.json``.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,6 +133,16 @@ pub enum Commands {
         #[arg(long)]
         no_pre_commit: bool,
     },
+    /// Continuously re-scan when dependency files change (filesystem watch)
+    Watch {
+        /// Path to the local project directory
+        #[arg(short, long, default_value = "./")]
+        path: String,
+
+        /// Milliseconds to wait after a change before re-scanning (debounce window)
+        #[arg(long, default_value_t = 500)]
+        debounce: u64,
+    },
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -554,7 +564,10 @@ mod tests {
                 assert_eq!(language, Some("rust".to_string()));
                 assert_eq!(project_license, Some("MIT".to_string()));
             }
-            Commands::Sbom { .. } | Commands::Cache { .. } | Commands::Init { .. } => {
+            Commands::Sbom { .. }
+            | Commands::Cache { .. }
+            | Commands::Init { .. }
+            | Commands::Watch { .. } => {
                 panic!("Expected Generate command");
             }
         }
@@ -601,7 +614,10 @@ mod tests {
                 assert_eq!(language, None);
                 assert_eq!(project_license, None);
             }
-            Commands::Sbom { .. } | Commands::Cache { .. } | Commands::Init { .. } => {
+            Commands::Sbom { .. }
+            | Commands::Cache { .. }
+            | Commands::Init { .. }
+            | Commands::Watch { .. } => {
                 panic!("Expected Generate command");
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,14 @@ mod generate;
 mod init;
 mod languages;
 mod licenses;
+mod manifest;
 mod parser;
 mod reporter;
 mod sbom;
 mod spdx;
 mod table;
 mod utils;
+mod watch;
 
 use clap::Parser;
 use cli::{print_version_info, Cli, Commands};
@@ -20,6 +22,7 @@ use generate::handle_generate_command;
 use init::handle_init_command;
 use licenses::{
     detect_project_license, is_license_compatible, set_github_token, LicenseCompatibility,
+    LicenseInfo,
 };
 use parser::parse_root;
 use reporter::{generate_report, ReportConfig};
@@ -214,11 +217,65 @@ fn run() -> FeludaResult<()> {
                 handle_init_command(path, force, no_pre_commit);
                 Ok(())
             }
+            Commands::Watch { path, debounce } => {
+                if args.gui {
+                    eprintln!(
+                        "❌ Watch mode does not support --gui (TUI) output. \
+                        Run `feluda watch` without --gui."
+                    );
+                    return Err(FeludaError::InvalidData(
+                        "Watch mode does not support --gui (TUI) output".to_string(),
+                    ));
+                }
+                if args.repo.is_some() {
+                    eprintln!("❌ Watch mode operates on a local path; --repo is not supported.");
+                    return Err(FeludaError::InvalidData(
+                        "Watch mode operates on a local path; --repo is not supported".to_string(),
+                    ));
+                }
+
+                let config = CheckConfig {
+                    path,
+                    json: args.json,
+                    yaml: args.yaml,
+                    verbose: args.verbose,
+                    restrictive: args.restrictive,
+                    gui: false,
+                    language: args.language.clone(),
+                    ci_format: args.ci_format.clone(),
+                    output_file: args.output_file.clone(),
+                    fail_on_restrictive: false,
+                    incompatible: args.incompatible,
+                    fail_on_incompatible: false,
+                    project_license: args.project_license.clone(),
+                    gist: args.gist,
+                    osi: args.osi.clone(),
+                    strict: args.strict,
+                    no_local: args.no_local,
+                };
+                watch::handle_watch_command(config, debounce)
+            }
         }
     }
 }
 
-fn handle_check_command(config: CheckConfig) -> FeludaResult<()> {
+/// Outcome of a single license analysis run.
+///
+/// Returned by [`report_analysis`] so callers (single-shot or watch) can decide
+/// what to do — e.g. set an exit code — without the analysis itself terminating
+/// the process.
+#[derive(Debug, Default, Clone, Copy)]
+struct ScanSummary {
+    has_restrictive: bool,
+    has_incompatible: bool,
+}
+
+/// Detect the project license and parse + analyze dependencies.
+///
+/// This is the shared front half of the check pipeline, reused by both the
+/// single-shot command and `feluda watch`. It performs no terminal I/O beyond
+/// logging and never exits the process.
+fn analyze_dependencies(config: &CheckConfig) -> FeludaResult<(Vec<LicenseInfo>, Option<String>)> {
     log(
         LogLevel::Info,
         &format!("Executing check command with path: {}", config.path),
@@ -230,7 +287,7 @@ fn handle_check_command(config: CheckConfig) -> FeludaResult<()> {
         &format!("Parsing dependencies in path: {}", config.path),
     );
 
-    let mut project_license = config.project_license;
+    let mut project_license = config.project_license.clone();
 
     // If no project license is provided via CLI, try to detect it
     if let Some(ref license) = project_license {
@@ -264,7 +321,7 @@ fn handle_check_command(config: CheckConfig) -> FeludaResult<()> {
     }
 
     // Parse and analyze dependencies
-    let mut analyzed_data = parse_root(
+    let analyzed_data = parse_root(
         &config.path,
         config.language.as_deref(),
         config.strict,
@@ -274,22 +331,26 @@ fn handle_check_command(config: CheckConfig) -> FeludaResult<()> {
 
     log_debug("Analyzed dependencies", &analyzed_data);
 
-    if analyzed_data.is_empty() {
-        log(LogLevel::Warn, "No dependencies found to analyze. Exiting.");
-        return Ok(());
-    }
+    Ok((analyzed_data, project_license))
+}
 
+/// Annotate each dependency with license-compatibility information relative to
+/// the project license. Mutates `analyzed_data` in place.
+fn annotate_compatibility(
+    analyzed_data: &mut [LicenseInfo],
+    project_license: &Option<String>,
+    strict: bool,
+) {
     // Update each dependency with compatibility information if project license is known
-    if let Some(ref proj_license) = project_license {
+    if let Some(proj_license) = project_license {
         log(
             LogLevel::Info,
             &format!("Checking license compatibility against project license: {proj_license}"),
         );
 
-        for info in &mut analyzed_data {
+        for info in analyzed_data.iter_mut() {
             if let Some(ref dep_license) = info.license {
-                info.compatibility =
-                    is_license_compatible(dep_license, proj_license, config.strict);
+                info.compatibility = is_license_compatible(dep_license, proj_license, strict);
 
                 log(
                     LogLevel::Info,
@@ -299,7 +360,7 @@ fn handle_check_command(config: CheckConfig) -> FeludaResult<()> {
                     ),
                 );
             } else {
-                info.compatibility = if config.strict {
+                info.compatibility = if strict {
                     LicenseCompatibility::Incompatible
                 } else {
                     LicenseCompatibility::Unknown
@@ -310,11 +371,7 @@ fn handle_check_command(config: CheckConfig) -> FeludaResult<()> {
                     &format!(
                         "License compatibility for {} {} (no license info)",
                         info.name,
-                        if config.strict {
-                            "incompatible"
-                        } else {
-                            "unknown"
-                        }
+                        if strict { "incompatible" } else { "unknown" }
                     ),
                 );
             }
@@ -326,171 +383,213 @@ fn handle_check_command(config: CheckConfig) -> FeludaResult<()> {
             "No project license specified or detected, marking all dependencies as unknown compatibility",
         );
 
-        for info in &mut analyzed_data {
+        for info in analyzed_data.iter_mut() {
             info.compatibility = LicenseCompatibility::Unknown;
         }
     }
+}
 
-    // Either run the GUI or generate a report
-    if config.gui {
-        let original_count = analyzed_data.len();
+/// Render the interactive TUI table for the analyzed dependencies.
+///
+/// GUI mode is single-shot only (it takes over the terminal and `color_eyre`
+/// can only be installed once per process), so it is intentionally not used by
+/// `feluda watch`.
+fn run_gui(
+    mut analyzed_data: Vec<LicenseInfo>,
+    project_license: Option<String>,
+    config: &CheckConfig,
+) -> FeludaResult<()> {
+    let original_count = analyzed_data.len();
 
-        // Filter for restrictive and incompatible
-        if config.restrictive || config.incompatible {
-            if project_license.is_some() {
-                log(
+    // Filter for restrictive and incompatible
+    if config.restrictive || config.incompatible {
+        if project_license.is_some() {
+            log(
                 LogLevel::Info,
                 "Restrictive and incompatible mode enabled, filtering for restrictive and incompatible licenses",
             );
-                analyzed_data.retain(|info| {
-                    (config.restrictive && *info.is_restrictive())
-                        || (config.incompatible
-                            && info.compatibility == LicenseCompatibility::Incompatible)
-                });
-
-                log(
-                    LogLevel::Info,
-                    &format!(
-                        "Filtered for restrictive and incompatible licenses: {} of {} dependencies",
-                        analyzed_data.len(),
-                        original_count
-                    ),
-                );
-            } else {
-                log(
-                LogLevel::Warn,
-                "Incompatible mode enabled but no project license specified, cannot filter for incompatible licenses",
-            );
-            }
-        } else if config.restrictive {
-            // Filter for restrictive
-            log(
-                LogLevel::Info,
-                "Restrictive mode enabled, filtering for restrictive licenses",
-            );
-            analyzed_data.retain(|info| *info.is_restrictive());
+            analyzed_data.retain(|info| {
+                (config.restrictive && *info.is_restrictive())
+                    || (config.incompatible
+                        && info.compatibility == LicenseCompatibility::Incompatible)
+            });
 
             log(
                 LogLevel::Info,
                 &format!(
-                    "Filtered for restrictive licenses: {} of {} dependencies",
+                    "Filtered for restrictive and incompatible licenses: {} of {} dependencies",
                     analyzed_data.len(),
                     original_count
                 ),
             );
-        } else if config.incompatible {
-            // Filter for incompatible if requested
-            if project_license.is_some() {
-                log(
-                    LogLevel::Info,
-                    "Incompatible mode enabled, filtering for incompatible licenses",
-                );
-                analyzed_data
-                    .retain(|info| info.compatibility == LicenseCompatibility::Incompatible);
-
-                log(
-                    LogLevel::Info,
-                    &format!(
-                        "Filtered for incompatible licenses: {} of {} dependencies",
-                        analyzed_data.len(),
-                        original_count
-                    ),
-                );
-            } else {
-                log(
+        } else {
+            log(
                 LogLevel::Warn,
                 "Incompatible mode enabled but no project license specified, cannot filter for incompatible licenses",
             );
-            }
         }
-
-        // Apply OSI filtering
-        if let Some(osi_filter) = &config.osi {
-            let before_count = analyzed_data.len();
-            match osi_filter {
-                cli::OsiFilter::Approved => {
-                    analyzed_data.retain(|info| info.osi_status == licenses::OsiStatus::Approved);
-                    log(
-                        LogLevel::Info,
-                        &format!(
-                            "Filtered for OSI approved licenses: {} of {} dependencies",
-                            analyzed_data.len(),
-                            before_count
-                        ),
-                    );
-                }
-                cli::OsiFilter::NotApproved => {
-                    analyzed_data
-                        .retain(|info| info.osi_status == licenses::OsiStatus::NotApproved);
-                    log(
-                        LogLevel::Info,
-                        &format!(
-                            "Filtered for non-OSI approved licenses: {} of {} dependencies",
-                            analyzed_data.len(),
-                            before_count
-                        ),
-                    );
-                }
-                cli::OsiFilter::Unknown => {
-                    analyzed_data.retain(|info| info.osi_status == licenses::OsiStatus::Unknown);
-                    log(
-                        LogLevel::Info,
-                        &format!(
-                            "Filtered for unknown OSI status licenses: {} of {} dependencies",
-                            analyzed_data.len(),
-                            before_count
-                        ),
-                    );
-                }
-            }
-        }
-
-        log(LogLevel::Info, "Starting TUI mode");
-
-        // Initialize the terminal
-        color_eyre::install()
-            .map_err(|e| FeludaError::TuiInit(format!("Failed to initialize color_eyre: {e}")))?;
-
-        let terminal = ratatui::init();
-        log(LogLevel::Info, "Terminal initialized for TUI");
-
-        // TUI app with project license info
-        let app_result = App::new(analyzed_data, project_license).run(terminal);
-        ratatui::restore();
-
-        // Handle any errors from the TUI
-        app_result.map_err(|e| FeludaError::TuiRuntime(format!("TUI error: {e}")))?;
-
-        log(LogLevel::Info, "TUI session completed successfully");
-    } else {
-        log(LogLevel::Info, "Generating dependency report");
-
-        // Create ReportConfig from CLI arguments
-        let report_config = ReportConfig::new(
-            config.json,
-            config.yaml,
-            config.verbose,
-            config.restrictive,
-            config.incompatible,
-            config.ci_format,
-            config.output_file,
-            project_license,
-            config.gist,
-            config.osi,
+    } else if config.restrictive {
+        // Filter for restrictive
+        log(
+            LogLevel::Info,
+            "Restrictive mode enabled, filtering for restrictive licenses",
         );
-
-        // Generate a report based on the analyzed data
-        let (has_restrictive, has_incompatible) = generate_report(analyzed_data, report_config);
+        analyzed_data.retain(|info| *info.is_restrictive());
 
         log(
             LogLevel::Info,
             &format!(
-                "Report generated, has_restrictive: {has_restrictive}, has_incompatible: {has_incompatible}"
+                "Filtered for restrictive licenses: {} of {} dependencies",
+                analyzed_data.len(),
+                original_count
             ),
         );
+    } else if config.incompatible {
+        // Filter for incompatible if requested
+        if project_license.is_some() {
+            log(
+                LogLevel::Info,
+                "Incompatible mode enabled, filtering for incompatible licenses",
+            );
+            analyzed_data.retain(|info| info.compatibility == LicenseCompatibility::Incompatible);
 
-        if (config.fail_on_restrictive && has_restrictive)
-            || (config.fail_on_incompatible && has_incompatible)
+            log(
+                LogLevel::Info,
+                &format!(
+                    "Filtered for incompatible licenses: {} of {} dependencies",
+                    analyzed_data.len(),
+                    original_count
+                ),
+            );
+        } else {
+            log(
+                LogLevel::Warn,
+                "Incompatible mode enabled but no project license specified, cannot filter for incompatible licenses",
+            );
+        }
+    }
+
+    // Apply OSI filtering
+    if let Some(osi_filter) = &config.osi {
+        let before_count = analyzed_data.len();
+        match osi_filter {
+            cli::OsiFilter::Approved => {
+                analyzed_data.retain(|info| info.osi_status == licenses::OsiStatus::Approved);
+                log(
+                    LogLevel::Info,
+                    &format!(
+                        "Filtered for OSI approved licenses: {} of {} dependencies",
+                        analyzed_data.len(),
+                        before_count
+                    ),
+                );
+            }
+            cli::OsiFilter::NotApproved => {
+                analyzed_data.retain(|info| info.osi_status == licenses::OsiStatus::NotApproved);
+                log(
+                    LogLevel::Info,
+                    &format!(
+                        "Filtered for non-OSI approved licenses: {} of {} dependencies",
+                        analyzed_data.len(),
+                        before_count
+                    ),
+                );
+            }
+            cli::OsiFilter::Unknown => {
+                analyzed_data.retain(|info| info.osi_status == licenses::OsiStatus::Unknown);
+                log(
+                    LogLevel::Info,
+                    &format!(
+                        "Filtered for unknown OSI status licenses: {} of {} dependencies",
+                        analyzed_data.len(),
+                        before_count
+                    ),
+                );
+            }
+        }
+    }
+
+    log(LogLevel::Info, "Starting TUI mode");
+
+    // Initialize the terminal
+    color_eyre::install()
+        .map_err(|e| FeludaError::TuiInit(format!("Failed to initialize color_eyre: {e}")))?;
+
+    let terminal = ratatui::init();
+    log(LogLevel::Info, "Terminal initialized for TUI");
+
+    // TUI app with project license info
+    let app_result = App::new(analyzed_data, project_license).run(terminal);
+    ratatui::restore();
+
+    // Handle any errors from the TUI
+    app_result.map_err(|e| FeludaError::TuiRuntime(format!("TUI error: {e}")))?;
+
+    log(LogLevel::Info, "TUI session completed successfully");
+
+    Ok(())
+}
+
+/// Generate a (non-interactive) dependency report and return the outcome.
+///
+/// Unlike the previous inline implementation, this never calls `process::exit`;
+/// the caller inspects the returned [`ScanSummary`] to decide on exit codes.
+/// This makes it safe to call repeatedly from `feluda watch`.
+fn report_analysis(
+    analyzed_data: Vec<LicenseInfo>,
+    project_license: Option<String>,
+    config: &CheckConfig,
+) -> ScanSummary {
+    log(LogLevel::Info, "Generating dependency report");
+
+    // Create ReportConfig from CLI arguments
+    let report_config = ReportConfig::new(
+        config.json,
+        config.yaml,
+        config.verbose,
+        config.restrictive,
+        config.incompatible,
+        config.ci_format.clone(),
+        config.output_file.clone(),
+        project_license,
+        config.gist,
+        config.osi.clone(),
+    );
+
+    // Generate a report based on the analyzed data
+    let (has_restrictive, has_incompatible) = generate_report(analyzed_data, report_config);
+
+    log(
+        LogLevel::Info,
+        &format!(
+            "Report generated, has_restrictive: {has_restrictive}, has_incompatible: {has_incompatible}"
+        ),
+    );
+
+    ScanSummary {
+        has_restrictive,
+        has_incompatible,
+    }
+}
+
+fn handle_check_command(config: CheckConfig) -> FeludaResult<()> {
+    let (mut analyzed_data, project_license) = analyze_dependencies(&config)?;
+
+    if analyzed_data.is_empty() {
+        log(LogLevel::Warn, "No dependencies found to analyze. Exiting.");
+        return Ok(());
+    }
+
+    annotate_compatibility(&mut analyzed_data, &project_license, config.strict);
+
+    // Either run the GUI or generate a report
+    if config.gui {
+        run_gui(analyzed_data, project_license, &config)?;
+    } else {
+        let summary = report_analysis(analyzed_data, project_license, &config);
+
+        if (config.fail_on_restrictive && summary.has_restrictive)
+            || (config.fail_on_incompatible && summary.has_incompatible)
         {
             log(
                 LogLevel::Warn,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,198 @@
+//! Single source of truth for the dependency-descriptor files Feluda understands.
+//!
+//! Both the scanner and `feluda watch` agree on "what counts as a dependency
+//! file" through this module, so the two never drift apart. Manifest
+//! recognition delegates to [`Language::from_file_name`] (the authority used by
+//! the parser to discover project roots); lockfiles are recognised on top of
+//! that here, because they are inputs to the analyzers rather than entry points.
+//!
+//! The scanner and the watcher differ only in *traversal*: the scanner scans a
+//! project root and resolves workspaces inside each language analyzer, while
+//! [`discover_dependency_files`] walks the whole tree (gitignore-aware) to build
+//! the set of files to monitor.
+
+use crate::languages::Language;
+use ignore::WalkBuilder;
+use std::path::{Path, PathBuf};
+
+/// What kind of dependency descriptor a file is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DepFileKind {
+    /// A manifest Feluda parses directly as a project entry point
+    /// (e.g. `Cargo.toml`, `package.json`, `pom.xml`).
+    Manifest,
+    /// A resolved lockfile whose changes reflect dependency changes
+    /// (e.g. `Cargo.lock`, `package-lock.json`, `go.sum`).
+    Lock,
+}
+
+/// Lockfiles that affect resolved dependencies but are not themselves project
+/// entry points recognised by [`Language::from_file_name`]. Lockfiles that are
+/// already recognised there (e.g. `Pipfile.lock`, `renv.lock`) are intentionally
+/// omitted to avoid double-counting.
+const LOCK_FILES: &[&str] = &[
+    "Cargo.lock",         // Rust
+    "package-lock.json",  // npm
+    "yarn.lock",          // Yarn
+    "pnpm-lock.yaml",     // pnpm
+    "go.sum",             // Go modules
+    "go.work.sum",        // Go workspaces
+    "uv.lock",            // Python (uv)
+    "packages.lock.json", // .NET
+];
+
+/// Directory names that are pruned from both discovery and change detection.
+/// These hold installed/vendored dependencies or VCS metadata and would
+/// otherwise produce huge, noisy watch sets.
+const PRUNED_DIRS: &[&str] = &["node_modules", ".git", "target", "vendor", ".venv", "venv"];
+
+/// Classify a file name as a dependency descriptor, if it is one.
+///
+/// Manifest recognition is delegated to [`Language::from_file_name`] so there is
+/// exactly one authority for it.
+pub fn classify(file_name: &str) -> Option<DepFileKind> {
+    if Language::from_file_name(file_name).is_some() {
+        Some(DepFileKind::Manifest)
+    } else if LOCK_FILES.contains(&file_name) {
+        Some(DepFileKind::Lock)
+    } else {
+        None
+    }
+}
+
+/// Whether a file name is any kind of dependency descriptor.
+pub fn is_dependency_file(file_name: &str) -> bool {
+    classify(file_name).is_some()
+}
+
+/// Whether `name` is a directory we prune from traversal/watching.
+fn is_pruned_dir(name: &str) -> bool {
+    PRUNED_DIRS.contains(&name)
+}
+
+/// Whether a filesystem change at `path` is a dependency change worth acting on.
+///
+/// Returns `true` only when the file itself is a dependency descriptor and none
+/// of its ancestor directories are pruned (so a `package.json` deep inside
+/// `node_modules/` is ignored).
+pub fn is_relevant_change(path: &Path) -> bool {
+    let pruned = path
+        .components()
+        .any(|component| component.as_os_str().to_str().is_some_and(is_pruned_dir));
+    if pruned {
+        return false;
+    }
+
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(is_dependency_file)
+}
+
+/// Recursively discover every dependency-descriptor file under `root`,
+/// honouring `.gitignore`/`.ignore` and skipping vendored dependency
+/// directories. This is the set `feluda watch` monitors.
+pub fn discover_dependency_files(root: impl AsRef<Path>) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+
+    let walker = WalkBuilder::new(root.as_ref())
+        .filter_entry(|entry| {
+            // Prune known vendor/VCS directories from traversal entirely.
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                if let Some(name) = entry.file_name().to_str() {
+                    return !is_pruned_dir(name);
+                }
+            }
+            true
+        })
+        .build();
+
+    for entry in walker.flatten() {
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        if let Some(name) = entry.file_name().to_str() {
+            if is_dependency_file(name) {
+                found.push(entry.into_path());
+            }
+        }
+    }
+
+    found.sort();
+    found.dedup();
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn classifies_manifests_via_language_authority() {
+        assert_eq!(classify("Cargo.toml"), Some(DepFileKind::Manifest));
+        assert_eq!(classify("package.json"), Some(DepFileKind::Manifest));
+        assert_eq!(classify("pom.xml"), Some(DepFileKind::Manifest));
+        assert_eq!(classify("requirements.txt"), Some(DepFileKind::Manifest));
+        assert_eq!(classify("MyApp.csproj"), Some(DepFileKind::Manifest));
+    }
+
+    #[test]
+    fn classifies_lockfiles() {
+        assert_eq!(classify("Cargo.lock"), Some(DepFileKind::Lock));
+        assert_eq!(classify("package-lock.json"), Some(DepFileKind::Lock));
+        assert_eq!(classify("go.sum"), Some(DepFileKind::Lock));
+        assert_eq!(classify("uv.lock"), Some(DepFileKind::Lock));
+    }
+
+    #[test]
+    fn ignores_unrelated_files() {
+        assert_eq!(classify("README.md"), None);
+        assert_eq!(classify("main.rs"), None);
+        assert!(!is_dependency_file("LICENSE"));
+    }
+
+    #[test]
+    fn change_under_pruned_dir_is_ignored() {
+        assert!(is_relevant_change(Path::new("Cargo.toml")));
+        assert!(is_relevant_change(Path::new("crates/foo/Cargo.toml")));
+        assert!(!is_relevant_change(Path::new(
+            "node_modules/foo/package.json"
+        )));
+        assert!(!is_relevant_change(Path::new("target/debug/Cargo.toml")));
+        assert!(!is_relevant_change(Path::new(".git/config")));
+    }
+
+    #[test]
+    fn discovers_dependency_files_recursively_and_prunes() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+
+        fs::write(root.join("Cargo.toml"), "[package]").unwrap();
+        fs::write(root.join("Cargo.lock"), "").unwrap();
+        fs::create_dir_all(root.join("crates/sub")).unwrap();
+        fs::write(root.join("crates/sub/Cargo.toml"), "[package]").unwrap();
+        fs::create_dir_all(root.join("node_modules/dep")).unwrap();
+        fs::write(root.join("node_modules/dep/package.json"), "{}").unwrap();
+        fs::write(root.join("README.md"), "# hi").unwrap();
+
+        let mut found: Vec<String> = discover_dependency_files(root)
+            .into_iter()
+            .filter_map(|p| {
+                p.strip_prefix(root)
+                    .ok()
+                    .map(|rel| rel.to_string_lossy().replace('\\', "/"))
+            })
+            .collect();
+        found.sort();
+
+        assert_eq!(
+            found,
+            vec![
+                "Cargo.lock".to_string(),
+                "Cargo.toml".to_string(),
+                "crates/sub/Cargo.toml".to_string(),
+            ]
+        );
+    }
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,141 @@
+//! `feluda watch` — continuous license compliance.
+//!
+//! Watches the project tree for filesystem changes and re-runs the license scan
+//! whenever a dependency descriptor changes. The set of files that count as a
+//! dependency change is defined by [`crate::manifest`], the same source of truth
+//! the scanner uses to recognise project files.
+//!
+//! Watch mode is report-only: it never opens the interactive TUI (`--gui`) and
+//! never exits on restrictive/incompatible findings — it just keeps reporting
+//! until interrupted (Ctrl-C).
+
+use crate::debug::{log, FeludaError, FeludaResult, LogLevel};
+use crate::manifest;
+use crate::{analyze_dependencies, annotate_compatibility, report_analysis, CheckConfig};
+use colored::Colorize;
+use notify::{Event, RecursiveMode, Watcher};
+use std::path::Path;
+use std::sync::mpsc::channel;
+use std::time::{Duration, Instant};
+
+/// Run a single scan-and-report pass without touching the process exit code.
+///
+/// Errors are logged and swallowed so a transient parse failure (e.g. an editor
+/// writing a half-finished manifest) doesn't tear down the watch session.
+fn scan_once(config: &CheckConfig) {
+    match analyze_dependencies(config) {
+        Ok((mut analyzed_data, project_license)) => {
+            if analyzed_data.is_empty() {
+                log(LogLevel::Warn, "No dependencies found to analyze.");
+                return;
+            }
+            annotate_compatibility(&mut analyzed_data, &project_license, config.strict);
+            let _ = report_analysis(analyzed_data, project_license, config);
+        }
+        Err(e) => {
+            // Keep watching even if this pass failed.
+            e.log();
+        }
+    }
+}
+
+/// Whether a batch of filesystem events touches any dependency descriptor.
+fn event_touches_dependency(result: &notify::Result<Event>) -> bool {
+    match result {
+        Ok(event) => event.paths.iter().any(|p| manifest::is_relevant_change(p)),
+        Err(_) => false,
+    }
+}
+
+/// Entry point for the `watch` subcommand.
+///
+/// `config.gui` is expected to be `false`; the caller rejects `--gui` before we
+/// get here.
+pub fn handle_watch_command(config: CheckConfig, debounce_ms: u64) -> FeludaResult<()> {
+    let path = config.path.clone();
+    let root = Path::new(&path);
+
+    if !root.exists() {
+        eprintln!("❌ Watch path does not exist: {path}");
+        return Err(FeludaError::InvalidData(format!(
+            "Watch path does not exist: {path}"
+        )));
+    }
+
+    log(
+        LogLevel::Info,
+        &format!("Starting watch mode on path: {path}"),
+    );
+
+    // Initial scan so the user sees the current state immediately.
+    scan_once(&config);
+
+    let watched = manifest::discover_dependency_files(root);
+    println!(
+        "\n{} {}",
+        "👁  Watching".bright_cyan().bold(),
+        format!(
+            "{} ({} dependency file{} tracked) — press Ctrl-C to stop",
+            path,
+            watched.len(),
+            if watched.len() == 1 { "" } else { "s" }
+        )
+        .bright_cyan()
+    );
+    if watched.is_empty() {
+        println!(
+            "{}",
+            "⚠  No dependency files found yet; will react when one appears.".yellow()
+        );
+    }
+
+    // Filesystem watcher. Events are delivered to the channel; we debounce bursts
+    // (editors emit several events per save) before re-scanning.
+    let (tx, rx) = channel::<notify::Result<Event>>();
+    let mut watcher = notify::recommended_watcher(move |res| {
+        let _ = tx.send(res);
+    })
+    .map_err(|e| FeludaError::InvalidData(format!("Failed to initialize file watcher: {e}")))?;
+
+    watcher
+        .watch(root, RecursiveMode::Recursive)
+        .map_err(|e| FeludaError::InvalidData(format!("Failed to watch {path}: {e}")))?;
+
+    let debounce = Duration::from_millis(debounce_ms);
+
+    loop {
+        // Block until the next event arrives (or the watcher goes away).
+        let first = match rx.recv() {
+            Ok(event) => event,
+            Err(_) => {
+                log(LogLevel::Warn, "Watch channel closed, stopping watch mode");
+                break;
+            }
+        };
+
+        if !event_touches_dependency(&first) {
+            continue;
+        }
+
+        // Debounce: drain any further events that arrive within the window so a
+        // single save (or a burst of related changes) triggers exactly one scan.
+        let deadline = Instant::now() + debounce;
+        while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+            match rx.recv_timeout(remaining) {
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+
+        println!(
+            "\n{} {}",
+            "🔄".bright_yellow(),
+            "Dependency change detected — re-scanning…"
+                .bright_yellow()
+                .bold()
+        );
+        scan_once(&config);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add a `watch` subcommand that monitors the project tree and re-runs the license scan whenever a dependency manifest or lockfile changes. This gives fast feedback while adding or upgrading dependencies — especially with AI coding tools that pull in packages on the fly — so license issues surface the moment they appear.

    # Watch the current directory
    feluda watch

    # Watch a specific path and widen the debounce window
    feluda watch --path /path/to/project/ --debounce 800

Watch mode reuses the normal scan flags when placed before the subcommand (e.g. `feluda --restrictive --json watch`). It is report-only: the interactive TUI (`--gui`) and remote repositories (`--repo`) are rejected, and it never sets a failing exit code. Press Ctrl-C to stop.

A new `manifest` module is the single source of truth for which files count as dependency descriptors, shared by the scanner and the watcher so the two cannot drift. Manifest recognition delegates to the existing `Language::from_file_name`; lockfiles are recognised on top. Discovery walks the tree gitignore-aware and prunes vendored directories (`node_modules/`, `target/`, `vendor/`, `.git/`).

To support repeated scans, the check pipeline in `main.rs` is split into reusable pieces (`analyze_dependencies`, `annotate_compatibility`, `run_gui`, `report_analysis`) that no longer call `process::exit`, so the watcher can drive them in a loop. Single-shot behavior is unchanged.