### PR TITLE
feat(ruby): add Ruby/Bundler license scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ feluda
 feluda --path /path/to/project/
 
 # Check with specific language
-feluda --language {rust|node|go|python|java|maven|gradle|c|cpp|r}
+feluda --language {rust|node|go|python|java|maven|gradle|c|cpp|r|ruby}
 
 # Skip local file checks and force network lookup only
 feluda --no-local

--- a/docs/source/supported-languages.rst
+++ b/docs/source/supported-languages.rst
@@ -112,6 +112,9 @@ Feluda currently supports projects written in these ecosystems:
    * - .NET (C#/F#/VB)
      - ``*.csproj``, ``*.fsproj``, ``packages.config``
      - NuGet packages
+   * - Ruby
+     - ``Gemfile.lock``, ``Gemfile``
+     - Bundler; ``Gemfile.lock`` carries the full resolved transitive set, licenses from RubyGems
 
 ----
 
@@ -133,13 +136,7 @@ Filter scans to a specific ecosystem using the ``--language`` flag:
    feluda --language cpp
    feluda --language dotnet
    feluda --language r
-
-----
-
-Coming Soon
------------
-
-- `Ruby <https://github.com/anistark/feluda/issues/53>`_
+   feluda --language ruby
 
 ----
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ This directory contains example projects for all supported languages in Feluda. 
 5. C Example (`c-example/`)
 6. C++ Example (`cpp-example/`)
 7. R Example (`r-example/`)
+8. Ruby Example (`ruby-example/`)
 
 ## Using Just Commands
 
@@ -47,6 +48,9 @@ feluda --path examples/cpp-example --project-license MIT
 
 # R project analysis
 feluda --path examples/r-example --verbose
+
+# Ruby project analysis (Gemfile.lock)
+feluda --path examples/ruby-example --verbose
 ```
 
 ## Contributing

--- a/examples/ruby-example/Gemfile
+++ b/examples/ruby-example/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "sinatra", "~> 3.1"
+gem "puma", "~> 6.4"
+gem "nokogiri", "~> 1.15"
+gem "rake", "~> 13.1"

--- a/examples/ruby-example/Gemfile.lock
+++ b/examples/ruby-example/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mini_portile2 (2.8.5)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.7.0)
+    nokogiri (1.15.5)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    puma (6.4.2)
+      nio4r (~> 2.0)
+    racc (1.7.3)
+    rack (2.2.8)
+    rack-protection (3.1.0)
+      rack (~> 2.2, >= 2.2.4)
+    rake (13.1.0)
+    ruby2_keywords (0.0.5)
+    sinatra (3.1.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.1.0)
+      tilt (~> 2.0)
+    tilt (2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  nokogiri (~> 1.15)
+  puma (~> 6.4)
+  rake (~> 13.1)
+  sinatra (~> 3.1)
+
+BUNDLED WITH
+   2.4.10

--- a/examples/ruby-example/README.md
+++ b/examples/ruby-example/README.md
@@ -1,0 +1,45 @@
+# Ruby Example Project for Feluda
+
+This is an example Ruby project designed to test Feluda's license analysis
+capabilities for Ruby/Bundler projects.
+
+## Dependencies
+
+This project declares a small Sinatra web app whose dependencies pull in several
+transitive gems:
+
+- **sinatra** — web framework (brings in `mustermann`, `rack`, `rack-protection`, `tilt`)
+- **puma** — web server (brings in `nio4r`)
+- **nokogiri** — HTML/XML parsing (brings in `mini_portile2`, `racc`)
+- **rake** — build tool
+
+## Project Files
+
+- `Gemfile` — direct dependency declarations
+- `Gemfile.lock` — resolved lockfile with the full transitive set at exact versions
+- `app.rb` — sample code using the dependencies
+
+Feluda prefers `Gemfile.lock` when present: it already contains every resolved
+gem (direct and transitive) with exact versions, so no registry resolution is
+needed. A project with only a `Gemfile` is parsed best-effort.
+
+## Testing with Feluda
+
+```sh
+# From the repository root
+feluda --path examples/ruby-example
+
+# Verbose output with OSI status
+feluda --path examples/ruby-example --verbose
+
+# JSON output
+feluda --path examples/ruby-example --json
+
+# License compatibility against your project license
+feluda --path examples/ruby-example --project-license MIT
+```
+
+## Expected Output
+
+Feluda resolves each gem's license from RubyGems and flags any that are
+restrictive or incompatible with your project license.

--- a/examples/ruby-example/app.rb
+++ b/examples/ruby-example/app.rb
@@ -1,0 +1,7 @@
+require "sinatra"
+require "nokogiri"
+
+get "/" do
+  doc = Nokogiri::HTML("<h1>Hello from Feluda</h1>")
+  doc.at_css("h1").text
+end

--- a/justfile
+++ b/justfile
@@ -125,6 +125,8 @@ examples:
     @echo "Run: feluda --path examples/c-example"
     @echo "\n📦 C++ Example:"
     @echo "Run: feluda --path examples/cpp-example"
+    @echo "\n📦 Ruby Example:"
+    @echo "Run: feluda --path examples/ruby-example"
 
 # Test Feluda on all example projects
 test-examples:
@@ -141,6 +143,8 @@ test-examples:
     ./target/debug/feluda --path examples/c-example || cargo run -- --path examples/c-example
     @echo "\n📦 Testing C++ Example:"
     ./target/debug/feluda --path examples/cpp-example || cargo run -- --path examples/cpp-example
+    @echo "\n📦 Testing Ruby Example:"
+    ./target/debug/feluda --path examples/ruby-example || cargo run -- --path examples/ruby-example
 
 # Documentation variables
 DOCS_DIR := "docs"

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -8,6 +8,7 @@ pub mod java;
 pub mod node;
 pub mod python;
 pub mod r;
+pub mod ruby;
 pub mod rust;
 
 use crate::licenses::LicenseInfo;
@@ -41,6 +42,7 @@ pub enum Language {
     Go(&'static str),
     Python(&'static [&'static str]),
     R(&'static [&'static str]),
+    Ruby(&'static [&'static str]),
 }
 
 impl Language {
@@ -57,6 +59,7 @@ impl Language {
             "MODULE.bazel" => Some(Language::Cpp(&CPP_PATHS[..])),
             "configure.ac" | "configure.in" | "Makefile" => Some(Language::C(&C_PATHS[..])),
             "CMakeLists.txt" => Some(Language::Cpp(&CPP_PATHS[..])),
+            "Gemfile" | "Gemfile.lock" => Some(Language::Ruby(&RUBY_PATHS[..])),
             _ => {
                 if file_name.ends_with(".csproj")
                     || file_name.ends_with(".fsproj")
@@ -101,6 +104,9 @@ pub const PYTHON_PATHS: [&str; 4] = [
 
 /// R project file patterns
 pub const R_PATHS: [&str; 2] = ["DESCRIPTION", "renv.lock"];
+
+/// Ruby project file patterns
+pub const RUBY_PATHS: [&str; 2] = ["Gemfile.lock", "Gemfile"];
 
 /// .NET project file patterns
 pub const DOTNET_PATHS: [&str; 4] = [".csproj", ".fsproj", ".vbproj", ".slnx"];

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -1,0 +1,344 @@
+use rayon::prelude::*;
+use regex::Regex;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+
+use crate::config::FeludaConfig;
+use crate::debug::{log, log_error, LogLevel};
+use crate::licenses::{
+    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+};
+
+#[derive(Debug, Clone)]
+struct RubyDependency {
+    name: String,
+    version: String,
+}
+
+pub fn analyze_ruby_licenses(file_path: &str, config: &FeludaConfig) -> Vec<LicenseInfo> {
+    log(
+        LogLevel::Info,
+        &format!("Analyzing Ruby dependencies from: {file_path}"),
+    );
+
+    let content = match fs::read_to_string(file_path) {
+        Ok(c) => c,
+        Err(e) => {
+            log_error(&format!("Failed to read Ruby file: {file_path}"), &e);
+            return Vec::new();
+        }
+    };
+
+    // `Gemfile.lock` is the resolved lockfile: it already contains the full
+    // transitive dependency set with exact versions, so no registry walk is
+    // needed (unlike Java). A bare `Gemfile` only lists direct, often
+    // constraint-versioned deps, so it is a best-effort fallback.
+    let deps = if file_path.ends_with("Gemfile.lock") {
+        parse_gemfile_lock(&content)
+    } else {
+        parse_gemfile(&content)
+    };
+
+    if deps.is_empty() {
+        log(LogLevel::Warn, "No Ruby dependencies found");
+        return Vec::new();
+    }
+
+    log(
+        LogLevel::Info,
+        &format!("Found {} Ruby dependencies", deps.len()),
+    );
+
+    let known_licenses = match fetch_licenses_from_github() {
+        Ok(licenses) => licenses,
+        Err(err) => {
+            log_error("Failed to fetch licenses from GitHub", &err);
+            HashMap::new()
+        }
+    };
+
+    deps.par_iter()
+        .map(|dep| {
+            let license = fetch_ruby_license(&dep.name, &dep.version);
+            let is_restrictive =
+                is_license_restrictive(&Some(license.clone()), &known_licenses, config.strict);
+
+            LicenseInfo {
+                name: dep.name.clone(),
+                version: dep.version.clone(),
+                license: Some(license.clone()),
+                is_restrictive,
+                compatibility: LicenseCompatibility::Unknown,
+                osi_status: crate::licenses::get_osi_status(&license),
+                sub_project: None,
+            }
+        })
+        .collect()
+}
+
+// =============================================================================
+// GEMFILE.LOCK PARSING
+// =============================================================================
+
+/// Parse the resolved gems from a `Gemfile.lock`.
+///
+/// Every `specs:` block (under `GEM`, and any `GIT`/`PATH` sources) lists its
+/// resolved gems at 4-space indentation as `name (version)`. Lines indented
+/// deeper are that gem's own constraints and are skipped, since each such gem
+/// also appears as its own top-level spec.
+fn parse_gemfile_lock(content: &str) -> Vec<RubyDependency> {
+    let spec_re = Regex::new(r"^    ([A-Za-z0-9._-]+) \(([^)]+)\)$").unwrap();
+    let mut deps: Vec<RubyDependency> = Vec::new();
+    let mut in_specs = false;
+
+    for line in content.lines() {
+        if line.trim() == "specs:" {
+            in_specs = true;
+            continue;
+        }
+
+        if !in_specs {
+            continue;
+        }
+
+        if line.trim().is_empty() {
+            in_specs = false;
+            continue;
+        }
+
+        let indent = line.len() - line.trim_start().len();
+        if indent < 4 {
+            // Dedented out of the specs block (e.g. a new top-level section).
+            in_specs = false;
+            continue;
+        }
+        if indent > 4 {
+            // A gem's own dependency constraint, not a resolved spec.
+            continue;
+        }
+
+        if let Some(cap) = spec_re.captures(line) {
+            deps.push(RubyDependency {
+                name: cap[1].to_string(),
+                version: strip_platform(&cap[2]),
+            });
+        }
+    }
+
+    deps.sort_by(|a, b| a.name.cmp(&b.name));
+    deps.dedup_by(|a, b| a.name == b.name);
+    deps
+}
+
+/// Drop a platform suffix from a locked gem version
+/// (e.g. `1.13.10-x86_64-linux` -> `1.13.10`). Ruby gem versions are
+/// dot-separated and never contain `-`, so the first `-` begins the platform.
+fn strip_platform(version: &str) -> String {
+    version
+        .split_once('-')
+        .map(|(v, _)| v)
+        .unwrap_or(version)
+        .to_string()
+}
+
+// =============================================================================
+// GEMFILE PARSING
+// =============================================================================
+
+/// Best-effort parse of direct dependencies declared in a `Gemfile`.
+/// Versions are optional and frequently constraints; an unresolvable version
+/// is left empty so the license lookup falls back to the latest release.
+fn parse_gemfile(content: &str) -> Vec<RubyDependency> {
+    let gem_re =
+        Regex::new(r#"(?m)^\s*gem\s+['"]([^'"]+)['"]\s*(?:,\s*['"]([^'"]+)['"])?"#).unwrap();
+
+    let mut deps: Vec<RubyDependency> = Vec::new();
+    for cap in gem_re.captures_iter(content) {
+        let name = cap[1].to_string();
+        let version = cap
+            .get(2)
+            .map(|m| clean_gem_version(m.as_str()))
+            .unwrap_or_default();
+        deps.push(RubyDependency { name, version });
+    }
+
+    deps.sort_by(|a, b| a.name.cmp(&b.name));
+    deps.dedup_by(|a, b| a.name == b.name);
+    deps
+}
+
+/// Extract a concrete version from a Gemfile constraint, dropping operators
+/// like `~>`, `>=`, `=`. Returns an empty string when no version token is found.
+fn clean_gem_version(constraint: &str) -> String {
+    let ver_re = Regex::new(r"[0-9][0-9A-Za-z.]*").unwrap();
+    ver_re
+        .find(constraint)
+        .map(|m| m.as_str().to_string())
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// RUBYGEMS LICENSE LOOKUP
+// =============================================================================
+
+fn fetch_ruby_license(name: &str, version: &str) -> String {
+    if !version.is_empty() {
+        if let Some(license) = fetch_license_for_version(name, version) {
+            return license;
+        }
+    }
+
+    fetch_license_latest(name).unwrap_or_else(|| "Unknown".to_string())
+}
+
+fn fetch_license_for_version(name: &str, version: &str) -> Option<String> {
+    let url = format!("https://rubygems.org/api/v2/rubygems/{name}/versions/{version}.json");
+    log(
+        LogLevel::Info,
+        &format!("Fetching RubyGems metadata: {url}"),
+    );
+    fetch_licenses_field(&url)
+}
+
+fn fetch_license_latest(name: &str) -> Option<String> {
+    let url = format!("https://rubygems.org/api/v1/gems/{name}.json");
+    log(
+        LogLevel::Info,
+        &format!("Fetching latest RubyGems metadata: {url}"),
+    );
+    fetch_licenses_field(&url)
+}
+
+/// Fetch a RubyGems JSON document and join its `licenses` array into a single
+/// SPDX string. Multiple licenses become an `A OR B` expression, which the
+/// compound-expression handling in `is_license_restrictive` understands.
+fn fetch_licenses_field(url: &str) -> Option<String> {
+    let response = reqwest::blocking::get(url).ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+
+    let json: Value = response.json().ok()?;
+    let licenses = json["licenses"].as_array()?;
+
+    let names: Vec<String> = licenses
+        .iter()
+        .filter_map(|l| l.as_str())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if names.is_empty() {
+        None
+    } else {
+        Some(names.join(" OR "))
+    }
+}
+
+// TESTS
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_gemfile_lock_basic() {
+        let content = r#"GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.4)
+      actionpack (= 7.0.4)
+      nio4r (~> 2.0)
+    nokogiri (1.13.10)
+      racc (~> 1.4)
+    racc (1.6.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails (~> 7.0)
+
+BUNDLED WITH
+   2.3.7
+"#;
+        let deps = parse_gemfile_lock(content);
+        let names: Vec<&str> = deps.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec!["actioncable", "nokogiri", "racc"]);
+        let actioncable = deps.iter().find(|d| d.name == "actioncable").unwrap();
+        assert_eq!(actioncable.version, "7.0.4");
+    }
+
+    #[test]
+    fn test_parse_gemfile_lock_strips_platform() {
+        let content = r#"GEM
+  specs:
+    nokogiri (1.13.10-x86_64-linux)
+    sqlite3 (1.5.4-arm64-darwin)
+"#;
+        let deps = parse_gemfile_lock(content);
+        let nokogiri = deps.iter().find(|d| d.name == "nokogiri").unwrap();
+        assert_eq!(nokogiri.version, "1.13.10");
+        let sqlite3 = deps.iter().find(|d| d.name == "sqlite3").unwrap();
+        assert_eq!(sqlite3.version, "1.5.4");
+    }
+
+    #[test]
+    fn test_parse_gemfile_lock_dedups() {
+        let content = r#"GIT
+  remote: https://github.com/example/foo.git
+  specs:
+    foo (1.0.0)
+
+GEM
+  specs:
+    foo (2.0.0)
+    bar (3.1.0)
+"#;
+        let deps = parse_gemfile_lock(content);
+        assert_eq!(deps.len(), 2);
+        let names: Vec<&str> = deps.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec!["bar", "foo"]);
+    }
+
+    #[test]
+    fn test_strip_platform() {
+        assert_eq!(strip_platform("1.13.10-x86_64-linux"), "1.13.10");
+        assert_eq!(strip_platform("1.0.0"), "1.0.0");
+        assert_eq!(strip_platform("2.0.0.beta1"), "2.0.0.beta1");
+    }
+
+    #[test]
+    fn test_parse_gemfile() {
+        let content = r#"source "https://rubygems.org"
+
+gem "rails", "~> 7.0.4"
+gem 'pg', '>= 0.18', '< 2.0'
+gem "puma"
+gem "redis", require: false
+"#;
+        let deps = parse_gemfile(content);
+        let names: Vec<&str> = deps.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec!["pg", "puma", "rails", "redis"]);
+
+        let rails = deps.iter().find(|d| d.name == "rails").unwrap();
+        assert_eq!(rails.version, "7.0.4");
+        let puma = deps.iter().find(|d| d.name == "puma").unwrap();
+        assert_eq!(puma.version, "");
+    }
+
+    #[test]
+    fn test_clean_gem_version() {
+        assert_eq!(clean_gem_version("~> 7.0.4"), "7.0.4");
+        assert_eq!(clean_gem_version(">= 0.18"), "0.18");
+        assert_eq!(clean_gem_version("= 1.2.3"), "1.2.3");
+        assert_eq!(clean_gem_version(">= 0"), "0");
+        assert_eq!(clean_gem_version(""), "");
+    }
+
+    #[test]
+    fn test_parse_gemfile_lock_empty() {
+        assert!(parse_gemfile_lock("").is_empty());
+        assert!(parse_gemfile("").is_empty());
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,11 +5,11 @@ use crate::debug::{log, log_debug, FeludaResult, LogLevel};
 use crate::languages::{
     c::analyze_c_licenses, cpp::analyze_cpp_licenses, dotnet::analyze_dotnet_licenses,
     go::analyze_go_licenses, java::analyze_java_licenses, node::analyze_js_licenses_with_no_local,
-    python::analyze_python_licenses, r::analyze_r_licenses,
+    python::analyze_python_licenses, r::analyze_r_licenses, ruby::analyze_ruby_licenses,
     rust::analyze_rust_licenses_with_metadata,
 };
 use crate::languages::{
-    Language, CPP_PATHS, C_PATHS, DOTNET_PATHS, JAVA_PATHS, PYTHON_PATHS, R_PATHS,
+    Language, CPP_PATHS, C_PATHS, DOTNET_PATHS, JAVA_PATHS, PYTHON_PATHS, RUBY_PATHS, R_PATHS,
 };
 use crate::licenses::{
     detect_project_license, is_license_compatible, LicenseCompatibility, LicenseInfo,
@@ -200,6 +200,28 @@ fn check_which_java_file_exists(project_path: impl AsRef<Path>) -> Option<String
         LogLevel::Warn,
         &format!(
             "No Java project file found in: {}",
+            project_path.as_ref().display()
+        ),
+    );
+    None
+}
+
+fn check_which_ruby_file_exists(project_path: impl AsRef<Path>) -> Option<String> {
+    for &path in RUBY_PATHS.iter() {
+        let full_path = Path::new(project_path.as_ref()).join(path);
+        if full_path.exists() {
+            log(
+                LogLevel::Info,
+                &format!("Found Ruby project file: {}", full_path.display()),
+            );
+            return Some(path.to_string());
+        }
+    }
+
+    log(
+        LogLevel::Warn,
+        &format!(
+            "No Ruby project file found in: {}",
             project_path.as_ref().display()
         ),
     );
@@ -406,6 +428,7 @@ fn matches_language(project_type: Language, language: &str) -> bool {
             | (Language::Go(_), "go")
             | (Language::Python(_), "python")
             | (Language::R(_), "r")
+            | (Language::Ruby(_), "ruby")
     )
 }
 
@@ -679,6 +702,34 @@ fn parse_dependencies(
                 }
                 None => {
                     log(LogLevel::Error, "R package file not found");
+                    Vec::new()
+                }
+            },
+            Language::Ruby(_) => match check_which_ruby_file_exists(project_path) {
+                Some(ruby_file) => {
+                    let project_path = Path::new(project_path).join(&ruby_file);
+                    log(
+                        LogLevel::Info,
+                        &format!("Parsing Ruby project: {}", project_path.display()),
+                    );
+
+                    indicator.update_progress(&format!("analyzing {ruby_file}"));
+
+                    match project_path.to_str() {
+                        Some(path_str) => {
+                            let deps = analyze_ruby_licenses(path_str, config);
+                            indicator
+                                .update_progress(&format!("found {} dependencies", deps.len()));
+                            deps
+                        }
+                        None => {
+                            log(LogLevel::Error, "Failed to convert Ruby path to string");
+                            Vec::new()
+                        }
+                    }
+                }
+                None => {
+                    log(LogLevel::Error, "Ruby project file not found");
                     Vec::new()
                 }
             },


### PR DESCRIPTION
Feluda now scans Ruby projects for dependency licenses. `Gemfile.lock` is the primary source: it already pins the full resolved transitive set at exact versions, so the whole graph is read directly with no registry walk. A bare `Gemfile` is parsed best-effort when no lockfile is present.

Licenses are resolved from RubyGems, with multiple licenses joined into an SPDX `A OR B` expression so the existing compound-expression handling classifies them correctly. Platform suffixes on locked versions (e.g. `1.13.10-x86_64-linux`) are stripped to the base version.

`Gemfile`/`Gemfile.lock` are registered with the shared manifest authority, so `feluda watch` picks them up automatically.

    feluda --path examples/ruby-example
    feluda --language ruby

Closes #53