### PR TITLE
refactor(licenses): unify license-text detection on shared SPDX engine

### DIFF
--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+    detect_license_from_content, fetch_licenses_from_github, is_license_restrictive,
+    LicenseCompatibility, LicenseInfo,
 };
 
 /// Go module names to exclude from dependency analysis
@@ -748,29 +749,6 @@ fn find_license_in_any_version(root: &Path, module: &str) -> Option<String> {
             }
         }
     }
-    None
-}
-
-fn detect_license_from_content(content: &str) -> Option<String> {
-    let content_upper = content.to_uppercase();
-
-    let patterns = vec![
-        ("MIT", "MIT License"),
-        ("APACHE", "Apache License"),
-        ("GPL", "GPL"),
-        ("BSD", "BSD"),
-        ("ISC", "ISC License"),
-        ("LGPL", "LGPL"),
-        ("UNLICENSE", "Unlicense"),
-        ("MPL", "Mozilla Public License"),
-    ];
-
-    for (pattern, label) in patterns {
-        if content_upper.contains(pattern) {
-            return Some(label.to_string());
-        }
-    }
-
     None
 }
 

--- a/src/languages/node.rs
+++ b/src/languages/node.rs
@@ -8,7 +8,8 @@ use std::process::Command;
 
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+    detect_license_from_content, fetch_licenses_from_github, is_license_restrictive,
+    LicenseCompatibility, LicenseInfo,
 };
 
 /// Type alias for dependency detection
@@ -1742,29 +1743,6 @@ fn get_license_from_local_license_file(project_root: &Path, package_name: &str) 
     None
 }
 
-fn detect_license_from_content(content: &str) -> Option<String> {
-    let content_upper = content.to_uppercase();
-
-    let patterns = vec![
-        ("MIT", "MIT License"),
-        ("APACHE", "Apache License"),
-        ("GPL", "GPL"),
-        ("BSD", "BSD"),
-        ("ISC", "ISC License"),
-        ("LGPL", "LGPL"),
-        ("UNLICENSE", "Unlicense"),
-        ("MPL", "Mozilla Public License"),
-    ];
-
-    for (pattern, label) in patterns {
-        if content_upper.contains(pattern) {
-            return Some(label.to_string());
-        }
-    }
-
-    None
-}
-
 fn get_nested_json_value<'a>(json: &'a Value, path: &[&str]) -> Option<&'a Value> {
     let mut current = json;
     for key in path {
@@ -2644,39 +2622,6 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn test_detect_license_from_content_mit() {
-        let mit_content = "MIT License\n\nCopyright (c) 2024";
-        assert_eq!(
-            detect_license_from_content(mit_content),
-            Some("MIT License".to_string())
-        );
-    }
-
-    #[test]
-    fn test_detect_license_from_content_apache() {
-        let apache_content = "Apache License\nVersion 2.0";
-        assert_eq!(
-            detect_license_from_content(apache_content),
-            Some("Apache License".to_string())
-        );
-    }
-
-    #[test]
-    fn test_detect_license_from_content_gpl() {
-        let gpl_content = "GNU GPL License\n\nVersion 2";
-        assert_eq!(
-            detect_license_from_content(gpl_content),
-            Some("GPL".to_string())
-        );
-    }
-
-    #[test]
-    fn test_detect_license_from_content_no_match() {
-        let unknown = "Some random content";
-        assert_eq!(detect_license_from_content(unknown), None);
-    }
-
-    #[test]
     fn test_get_license_from_local_license_file_mit() {
         let temp_dir = TempDir::new().unwrap();
         let package_dir = temp_dir.path().join("node_modules").join("test-pkg");
@@ -2686,7 +2631,7 @@ mod tests {
         fs::write(&license_path, "MIT License\n\nCopyright (c) 2024").unwrap();
 
         let result = get_license_from_local_license_file(temp_dir.path(), "test-pkg");
-        assert_eq!(result, Some("MIT License".to_string()));
+        assert_eq!(result, Some("MIT".to_string()));
     }
 
     #[test]
@@ -2700,10 +2645,10 @@ mod tests {
         fs::create_dir_all(&package_dir).unwrap();
 
         let license_path = package_dir.join("LICENSE.md");
-        fs::write(&license_path, "Apache License").unwrap();
+        fs::write(&license_path, "Apache License\nVersion 2.0, January 2004").unwrap();
 
         let result = get_license_from_local_license_file(temp_dir.path(), "@scope/package");
-        assert_eq!(result, Some("Apache License".to_string()));
+        assert_eq!(result, Some("Apache-2.0".to_string()));
     }
 
     #[test]
@@ -2725,10 +2670,14 @@ mod tests {
         fs::create_dir_all(&package_dir).unwrap();
 
         let license_path = package_dir.join("LICENSE.txt");
-        fs::write(&license_path, "BSD License").unwrap();
+        fs::write(
+            &license_path,
+            "BSD 2-Clause License\n\nRedistribution and use in source and binary forms",
+        )
+        .unwrap();
 
         let result = get_license_from_local_license_file(temp_dir.path(), "test-pkg");
-        assert_eq!(result, Some("BSD".to_string()));
+        assert_eq!(result, Some("BSD-2-Clause".to_string()));
     }
 
     #[test]

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -10,7 +10,8 @@ use toml::Value as TomlValue;
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+    detect_license_from_content, fetch_licenses_from_github, is_license_restrictive,
+    LicenseCompatibility, LicenseInfo,
 };
 
 /// Represents an environment marker in a Python requirement
@@ -518,29 +519,6 @@ fn check_site_package_license_file(site_packages: &Path, package_name: &str) -> 
             }
         }
     }
-    None
-}
-
-fn detect_license_from_content(content: &str) -> Option<String> {
-    let content_upper = content.to_uppercase();
-
-    let patterns = vec![
-        ("MIT", "MIT License"),
-        ("APACHE", "Apache License"),
-        ("GPL", "GPL"),
-        ("BSD", "BSD"),
-        ("ISC", "ISC License"),
-        ("LGPL", "LGPL"),
-        ("UNLICENSE", "Unlicense"),
-        ("MPL", "Mozilla Public License"),
-    ];
-
-    for (pattern, label) in patterns {
-        if content_upper.contains(pattern) {
-            return Some(label.to_string());
-        }
-    }
-
     None
 }
 

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -1144,6 +1144,15 @@ static LICENSE_CONTENT_RULES: &[LicenseContentRule] = &[
         spdx_id: "ISC",
         marker_groups: &[&["ISC License"]],
     },
+    // Unlicense text is distinctive and shares no preamble with the licenses above,
+    // so ordering relative to them does not matter.
+    LicenseContentRule {
+        spdx_id: "Unlicense",
+        marker_groups: &[
+            &["This is free and unencumbered software released into the public domain"],
+            &["unlicense.org"],
+        ],
+    },
 ];
 
 /// Return the SPDX ID for the first content rule that matches `content`, or `None`.
@@ -1156,6 +1165,17 @@ fn match_license_content(content: &str) -> Option<&'static str> {
         }
     }
     None
+}
+
+/// Detect a license's SPDX identifier from the **text content** of a license file
+/// (`LICENSE`, `COPYING`, …) or any blob of license text.
+///
+/// Returns a canonical SPDX id (e.g. `"MIT"`, `"Apache-2.0"`) when the content matches a
+/// known license, or `None` otherwise. This is the single shared implementation that every
+/// language analyzer's local-license-file fallback routes through, so detection stays
+/// consistent (and SPDX-correct) across ecosystems.
+pub fn detect_license_from_content(content: &str) -> Option<String> {
+    match_license_content(content).map(str::to_string)
 }
 
 /// Detect the project's license
@@ -1538,5 +1558,47 @@ mod tests {
     fn test_is_license_ignored_empty_license() {
         // Empty string should return false
         assert!(!is_license_ignored(Some("")));
+    }
+
+    #[test]
+    fn test_detect_license_from_content_returns_spdx_ids() {
+        // The shared detector returns canonical SPDX ids, not free-form labels.
+        assert_eq!(
+            detect_license_from_content("MIT License\n\nCopyright (c) 2024"),
+            Some("MIT".to_string())
+        );
+        assert_eq!(
+            detect_license_from_content("Apache License\nVersion 2.0"),
+            Some("Apache-2.0".to_string())
+        );
+        assert_eq!(
+            detect_license_from_content("GNU GENERAL PUBLIC LICENSE\nVersion 2, June 1991"),
+            Some("GPL-2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_license_from_content_lgpl_not_gpl() {
+        // Regression guard: the old per-language detectors matched the bare "GPL"
+        // substring before "LGPL", so an LGPL file was reported as GPL.
+        let lgpl = "GNU LESSER GENERAL PUBLIC LICENSE\nVersion 3, 29 June 2007";
+        assert_eq!(
+            detect_license_from_content(lgpl),
+            Some("LGPL-3.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_license_from_content_unlicense() {
+        let unlicense = "This is free and unencumbered software released into the public domain.";
+        assert_eq!(
+            detect_license_from_content(unlicense),
+            Some("Unlicense".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_license_from_content_no_match() {
+        assert_eq!(detect_license_from_content("Some random content"), None);
     }
 }


### PR DESCRIPTION
node, go, and python each carried an identical copy of a crude `detect_license_from_content` that matched bare substrings and returned free-form labels ("MIT License", "GPL", "BSD"). Two problems followed: the labels were not SPDX ids, so downstream restrictive, compatibility, and OSI checks (which key off SPDX ids) matched inconsistently; and the substring order tested "GPL" before "LGPL", so every LGPL dependency was reported as GPL.

Route all three analyzers through the existing, well-ordered content engine in `licenses.rs`, now exposed as `detect_license_from_content`, which returns canonical SPDX ids and orders rules specific-to-general (AGPL/LGPL before GPL, BSD-3 before BSD-2). Add an `Unlicense` content rule so consolidation keeps the one license the old detectors caught that the engine did not.

Local license-file fallbacks now yield SPDX ids (`MIT`, `Apache-2.0`, `BSD-2-Clause`) instead of free-form labels. The three duplicate implementations are removed.