### PR TITLE
feat(licenses): add local license-file fallback across analyzers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +468,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +618,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -806,6 +835,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -850,6 +880,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1781,6 +1821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3034,6 +3075,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -4562,7 +4609,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ dirs = "6.0"
 semver = "1.0"
 quick-xml = { version = "0.37", features = ["serialize"] }
 notify = "8.2.0"
+zip = { version = "2.2", default-features = false, features = ["deflate"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/languages/c.rs
+++ b/src/languages/c.rs
@@ -7,7 +7,8 @@ use std::process::Command;
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+    detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
+    LicenseCompatibility, LicenseInfo,
 };
 
 pub fn analyze_c_licenses(project_path: &str, config: &FeludaConfig) -> Vec<LicenseInfo> {
@@ -552,7 +553,22 @@ fn fetch_license_for_c_dependency(name: &str, version: &str) -> String {
         }
     }
 
+    // Local fallback: Debian-style installs ship a license at /usr/share/doc/<pkg>/copyright.
+    if let Some(license) = detect_license_in_system_doc_dir(name) {
+        return license;
+    }
+
     format!("Unknown license for {name}: {version}")
+}
+
+/// Probe `/usr/share/doc/<pkg>/` for a bundled license file (Debian's `copyright`
+/// convention), routing through the shared [`detect_license_in_dir`] engine.
+fn detect_license_in_system_doc_dir(package_name: &str) -> Option<String> {
+    detect_license_in_doc_root(Path::new("/usr/share/doc"), package_name)
+}
+
+fn detect_license_in_doc_root(doc_root: &Path, package_name: &str) -> Option<String> {
+    detect_license_in_dir(&doc_root.join(package_name))
 }
 
 fn get_system_package_license(package_name: &str) -> Result<String, String> {
@@ -589,6 +605,28 @@ fn get_system_package_license(package_name: &str) -> Result<String, String> {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_detect_license_in_doc_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let pkg_doc = temp_dir.path().join("zlib1g");
+        fs::create_dir_all(&pkg_doc).unwrap();
+        // Debian ships license text in a `copyright` file.
+        fs::write(
+            pkg_doc.join("copyright"),
+            "BSD 2-Clause License\n\nRedistribution and use in source and binary forms",
+        )
+        .unwrap();
+
+        assert_eq!(
+            detect_license_in_doc_root(temp_dir.path(), "zlib1g"),
+            Some("BSD-2-Clause".to_string())
+        );
+        assert_eq!(
+            detect_license_in_doc_root(temp_dir.path(), "nonexistent"),
+            None
+        );
+    }
 
     #[test]
     fn test_parse_autotools_dependencies() {

--- a/src/languages/cpp.rs
+++ b/src/languages/cpp.rs
@@ -2,13 +2,14 @@ use regex::Regex;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+    detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
+    LicenseCompatibility, LicenseInfo,
 };
 
 #[derive(Debug, Clone)]
@@ -651,7 +652,34 @@ fn fetch_license_from_vcpkg_registry(package_name: &str) -> String {
         }
     }
 
+    // Local fallback: vcpkg installs a copyright file at
+    // <VCPKG_ROOT>/installed/<triplet>/share/<port>/copyright.
+    if let Some(root) = vcpkg_root() {
+        if let Some(license) = detect_license_in_vcpkg_install(&root, package_name) {
+            return license;
+        }
+    }
+
     format!("Unknown license (vcpkg: {package_name})")
+}
+
+/// The vcpkg root, from the `VCPKG_ROOT` env var.
+fn vcpkg_root() -> Option<PathBuf> {
+    std::env::var("VCPKG_ROOT").ok().map(PathBuf::from)
+}
+
+/// Probe a vcpkg tree for an installed port's bundled license file. The triplet
+/// (e.g. `x64-linux`) varies, so every `installed/<triplet>/share/<port>/` dir is tried.
+fn detect_license_in_vcpkg_install(vcpkg_root: &Path, port: &str) -> Option<String> {
+    let installed = vcpkg_root.join("installed");
+    let entries = fs::read_dir(&installed).ok()?;
+    for entry in entries.flatten() {
+        let share_pkg = entry.path().join("share").join(port);
+        if let Some(license) = detect_license_in_dir(&share_pkg) {
+            return Some(license);
+        }
+    }
+    None
 }
 
 fn fetch_license_from_conan_center(package_name: &str, version: &str) -> String {
@@ -667,6 +695,8 @@ fn fetch_license_from_conan_center(package_name: &str, version: &str) -> String 
         }
     }
 
+    // No local fallback for Conan: its content-addressed cache (~/.conan2/p/<hash>) can't be
+    // mapped to a package name without the `conan` CLI, so file probing isn't reliable here.
     format!("Unknown license (conan: {package_name})")
 }
 
@@ -683,6 +713,11 @@ fn fetch_license_from_system_package(package_name: &str) -> String {
         }
     }
 
+    // Local fallback: Debian-style installs ship a license at /usr/share/doc/<pkg>/copyright.
+    if let Some(license) = detect_license_in_dir(&Path::new("/usr/share/doc").join(package_name)) {
+        return license;
+    }
+
     format!("Unknown license (system: {package_name})")
 }
 
@@ -690,6 +725,33 @@ fn fetch_license_from_system_package(package_name: &str) -> String {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_detect_license_in_vcpkg_install() {
+        let temp_dir = TempDir::new().unwrap();
+        // <root>/installed/x64-linux/share/zlib/copyright
+        let share_pkg = temp_dir
+            .path()
+            .join("installed")
+            .join("x64-linux")
+            .join("share")
+            .join("zlib");
+        fs::create_dir_all(&share_pkg).unwrap();
+        fs::write(
+            share_pkg.join("copyright"),
+            "zlib License\n\nApache License\nVersion 2.0, January 2004",
+        )
+        .unwrap();
+
+        assert_eq!(
+            detect_license_in_vcpkg_install(temp_dir.path(), "zlib"),
+            Some("Apache-2.0".to_string())
+        );
+        assert_eq!(
+            detect_license_in_vcpkg_install(temp_dir.path(), "nonexistent"),
+            None
+        );
+    }
 
     #[test]
     fn test_parse_vcpkg_dependencies() {

--- a/src/languages/dotnet.rs
+++ b/src/languages/dotnet.rs
@@ -9,7 +9,8 @@ use std::process::Command;
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+    detect_license_from_content, detect_license_in_dir, fetch_licenses_from_github,
+    is_license_restrictive, LicenseCompatibility, LicenseInfo,
 };
 
 #[derive(Debug, Clone)]
@@ -377,20 +378,23 @@ fn fetch_from_local_nuget_cache(name: &str, version: &str) -> Result<String, Str
         .or_else(|_| std::env::var("USERPROFILE"))
         .map_err(|_| "Cannot determine home directory")?;
 
-    let nuget_cache = PathBuf::from(home)
+    let package_dir = PathBuf::from(home)
         .join(".nuget")
         .join("packages")
         .join(name.to_lowercase())
-        .join(version)
-        .join(format!("{}.nuspec", name.to_lowercase()));
+        .join(version);
 
-    if nuget_cache.exists() {
+    let nuspec_path = package_dir.join(format!("{}.nuspec", name.to_lowercase()));
+    if nuspec_path.exists() {
         let content =
-            fs::read_to_string(&nuget_cache).map_err(|e| format!("Failed to read nuspec: {e}"))?;
-        return parse_license_from_nuspec(&content);
+            fs::read_to_string(&nuspec_path).map_err(|e| format!("Failed to read nuspec: {e}"))?;
+        if let Some(license) = resolve_nuspec_license(&content, Some(&package_dir)) {
+            return Ok(license);
+        }
     }
 
-    Err("Not found in local cache".to_string())
+    // Final local fallback: probe the package dir for a bundled LICENSE/COPYING file.
+    detect_license_in_dir(&package_dir).ok_or_else(|| "Not found in local cache".to_string())
 }
 
 fn fetch_from_nuget_api(name: &str, version: &str) -> Result<String, String> {
@@ -424,13 +428,46 @@ fn fetch_from_nuget_api(name: &str, version: &str) -> Result<String, String> {
         .text()
         .map_err(|e| format!("Failed to read response: {e}"))?;
 
-    parse_license_from_nuspec(&content)
+    // No local package dir over the API, so file-type licenses can't be resolved here.
+    resolve_nuspec_license(&content, None).ok_or_else(|| "No license found in nuspec".to_string())
 }
 
-fn parse_license_from_nuspec(content: &str) -> Result<String, String> {
-    if let Ok(re) = Regex::new(r"<license[^>]*>([^<]+)</license>") {
+/// A `<license>` declaration in a nuspec.
+enum NuspecLicense {
+    /// An SPDX expression (`<license type="expression">` or a recognized `<licenseUrl>`).
+    Expression(String),
+    /// `<license type="file">` — the value is a path to a bundled license file, relative to
+    /// the package root, which must be read and content-detected.
+    File(String),
+    None,
+}
+
+/// Resolve a nuspec's license to a canonical value.
+///
+/// `package_dir` is the local package root, used to read `type="file"` licenses; pass `None`
+/// when parsing a nuspec fetched over the network (file licenses then resolve to `None`).
+fn resolve_nuspec_license(content: &str, package_dir: Option<&Path>) -> Option<String> {
+    match parse_license_from_nuspec(content) {
+        NuspecLicense::Expression(spdx) => Some(spdx),
+        NuspecLicense::File(rel) => {
+            let dir = package_dir?;
+            let text = fs::read_to_string(dir.join(&rel)).ok()?;
+            detect_license_from_content(&text)
+        }
+        NuspecLicense::None => None,
+    }
+}
+
+fn parse_license_from_nuspec(content: &str) -> NuspecLicense {
+    if let Ok(re) = Regex::new(r"<license([^>]*)>([^<]+)</license>") {
         if let Some(cap) = re.captures(content) {
-            return Ok(cap[1].trim().to_string());
+            let attrs = &cap[1];
+            let value = cap[2].trim().to_string();
+            // `type="file"` means the value is a filename, not an SPDX id.
+            if attrs.contains(r#"type="file""#) {
+                return NuspecLicense::File(value);
+            }
+            return NuspecLicense::Expression(value);
         }
     }
 
@@ -438,19 +475,19 @@ fn parse_license_from_nuspec(content: &str) -> Result<String, String> {
         if let Some(cap) = re.captures(content) {
             let url = cap[1].trim();
             if url.contains("MIT") {
-                return Ok("MIT".to_string());
+                return NuspecLicense::Expression("MIT".to_string());
             } else if url.contains("Apache") {
-                return Ok("Apache-2.0".to_string());
+                return NuspecLicense::Expression("Apache-2.0".to_string());
             } else if url.contains("BSD") {
-                return Ok("BSD".to_string());
+                return NuspecLicense::Expression("BSD".to_string());
             } else if url.contains("GPL") {
-                return Ok("GPL".to_string());
+                return NuspecLicense::Expression("GPL".to_string());
             }
-            return Ok(url.to_string());
+            return NuspecLicense::Expression(url.to_string());
         }
     }
 
-    Err("No license found in nuspec".to_string())
+    NuspecLicense::None
 }
 
 fn find_file_in_dir(dir: &Path, filename: &str) -> Result<String, String> {
@@ -462,5 +499,64 @@ fn find_file_in_dir(dir: &Path, filename: &str) -> Result<String, String> {
             .ok_or_else(|| "Invalid path".to_string())
     } else {
         Err(format!("{filename} not found in directory"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_resolve_nuspec_license_expression() {
+        let nuspec =
+            r#"<package><metadata><license type="expression">MIT</license></metadata></package>"#;
+        assert_eq!(
+            resolve_nuspec_license(nuspec, None),
+            Some("MIT".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_nuspec_license_file_resolves_from_package_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(
+            temp_dir.path().join("LICENSE.txt"),
+            "Apache License\nVersion 2.0, January 2004",
+        )
+        .unwrap();
+
+        // type="file" points at a bundled license; its content is detected, not the filename.
+        let nuspec =
+            r#"<package><metadata><license type="file">LICENSE.txt</license></metadata></package>"#;
+        assert_eq!(
+            resolve_nuspec_license(nuspec, Some(temp_dir.path())),
+            Some("Apache-2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_nuspec_license_file_without_package_dir() {
+        // Over the API we have no package dir, so a file-type license can't be resolved.
+        let nuspec =
+            r#"<package><metadata><license type="file">LICENSE.txt</license></metadata></package>"#;
+        assert_eq!(resolve_nuspec_license(nuspec, None), None);
+    }
+
+    #[test]
+    fn test_resolve_nuspec_license_url() {
+        let nuspec = r#"<package><metadata><licenseUrl>https://opensource.org/licenses/MIT</licenseUrl></metadata></package>"#;
+        assert_eq!(
+            resolve_nuspec_license(nuspec, None),
+            Some("MIT".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_nuspec_license_none() {
+        assert_eq!(
+            resolve_nuspec_license("<package><metadata></metadata></package>", None),
+            None
+        );
     }
 }

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    detect_license_from_content, fetch_licenses_from_github, is_license_restrictive,
+    detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
 
@@ -657,7 +657,7 @@ fn get_license_from_local_go_mod(package_name: &str) -> Option<String> {
 fn get_license_from_go_module_cache(package_name: &str, version: &str) -> Option<String> {
     let module_cache = get_gomodcache_path()?;
     let exact_path = build_module_cache_path(&module_cache, package_name, version);
-    if let Some(license) = read_license_from_dir(&exact_path) {
+    if let Some(license) = detect_license_in_dir(&exact_path) {
         return Some(license);
     }
     find_license_in_any_version(&module_cache, package_name)
@@ -709,31 +709,6 @@ fn build_module_cache_path(root: &Path, module: &str, version: &str) -> PathBuf 
     root.join(format!("{escaped}@{version}"))
 }
 
-fn read_license_from_dir(dir: &Path) -> Option<String> {
-    if !dir.exists() {
-        return None;
-    }
-
-    let license_files = [
-        "LICENSE",
-        "LICENSE.txt",
-        "LICENSE.md",
-        "COPYING",
-        "COPYING.md",
-    ];
-    for license_file in &license_files {
-        let license_path = dir.join(license_file);
-        if license_path.exists() {
-            if let Ok(content) = fs::read_to_string(&license_path) {
-                if let Some(license) = detect_license_from_content(&content) {
-                    return Some(license);
-                }
-            }
-        }
-    }
-    None
-}
-
 fn find_license_in_any_version(root: &Path, module: &str) -> Option<String> {
     let escaped = escape_go_module_path(module);
     let prefix = format!("{escaped}@");
@@ -742,7 +717,7 @@ fn find_license_in_any_version(root: &Path, module: &str) -> Option<String> {
             let path = entry.path();
             if let Some(file_name) = path.file_name().and_then(|s| s.to_str()) {
                 if file_name.starts_with(&prefix) {
-                    if let Some(license) = read_license_from_dir(&path) {
+                    if let Some(license) = detect_license_in_dir(&path) {
                         return Some(license);
                     }
                 }

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -4,13 +4,15 @@ use rayon::prelude::*;
 use regex::Regex;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
-use std::path::Path;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+    detect_license_from_content, fetch_licenses_from_github, is_license_restrictive,
+    LicenseCompatibility, LicenseInfo,
 };
 
 #[derive(Debug, Clone)]
@@ -494,7 +496,77 @@ fn fetch_maven_license(group_id: &str, artifact_id: &str, version: &str) -> Stri
         return license;
     }
 
+    // Local fallback: read the license text bundled inside the cached jar.
+    if let Some(license) = fetch_license_from_local_jar(group_id, artifact_id, version) {
+        return license;
+    }
+
     "Unknown".to_string()
+}
+
+/// License files conventionally bundled inside a jar, in priority order. Maven artifacts
+/// place them under `META-INF/`; some older jars keep them at the archive root.
+const JAR_LICENSE_ENTRIES: &[&str] = &[
+    "META-INF/LICENSE",
+    "META-INF/LICENSE.txt",
+    "META-INF/LICENSE.md",
+    "META-INF/COPYING",
+    "LICENSE",
+    "LICENSE.txt",
+    "LICENSE.md",
+    "COPYING",
+];
+
+/// Probe the locally cached jar for a bundled license file and content-detect it.
+///
+/// The jar lives at `<repo>/<group as path>/<artifact>/<version>/<artifact>-<version>.jar`,
+/// where the repo is `MAVEN_REPO_LOCAL` or the default `~/.m2/repository`.
+fn fetch_license_from_local_jar(
+    group_id: &str,
+    artifact_id: &str,
+    version: &str,
+) -> Option<String> {
+    // A concrete version is required to locate the jar on disk.
+    if version.is_empty() || version == "RELEASE" {
+        return None;
+    }
+
+    let repo = maven_local_repo()?;
+    let jar_path = repo
+        .join(group_id.replace('.', "/"))
+        .join(artifact_id)
+        .join(version)
+        .join(format!("{artifact_id}-{version}.jar"));
+
+    detect_license_in_jar(&jar_path)
+}
+
+fn maven_local_repo() -> Option<PathBuf> {
+    if let Ok(repo) = std::env::var("MAVEN_REPO_LOCAL") {
+        return Some(PathBuf::from(repo));
+    }
+    dirs::home_dir().map(|home| home.join(".m2").join("repository"))
+}
+
+fn detect_license_in_jar(jar_path: &Path) -> Option<String> {
+    let file = fs::File::open(jar_path).ok()?;
+    let mut archive = zip::ZipArchive::new(file).ok()?;
+
+    for entry_name in JAR_LICENSE_ENTRIES {
+        if let Ok(mut entry) = archive.by_name(entry_name) {
+            let mut content = String::new();
+            if entry.read_to_string(&mut content).is_ok() {
+                if let Some(spdx) = detect_license_from_content(&content) {
+                    log(
+                        LogLevel::Info,
+                        &format!("Detected {spdx} from jar entry {entry_name}"),
+                    );
+                    return Some(spdx);
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Maximum number of parent POMs to follow when resolving a license. Guards
@@ -674,6 +746,60 @@ mod tests {
         assert_eq!(dep.group_id, "com.google.guava");
         assert_eq!(dep.artifact_id, "guava");
         assert_eq!(dep.version, "31.1-jre");
+    }
+
+    #[test]
+    fn test_detect_license_in_jar() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+
+        let temp_dir = TempDir::new().unwrap();
+        let jar_path = temp_dir.path().join("guava-32.0.jar");
+        let file = fs::File::create(&jar_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        zip.start_file("META-INF/LICENSE", SimpleFileOptions::default())
+            .unwrap();
+        zip.write_all(b"Apache License\nVersion 2.0, January 2004")
+            .unwrap();
+        zip.finish().unwrap();
+
+        assert_eq!(
+            detect_license_in_jar(&jar_path),
+            Some("Apache-2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_license_in_jar_no_license_entry() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+
+        let temp_dir = TempDir::new().unwrap();
+        let jar_path = temp_dir.path().join("nolicense-1.0.jar");
+        let file = fs::File::create(&jar_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        zip.start_file("com/example/Main.class", SimpleFileOptions::default())
+            .unwrap();
+        zip.write_all(b"not a license").unwrap();
+        zip.finish().unwrap();
+
+        assert_eq!(detect_license_in_jar(&jar_path), None);
+    }
+
+    #[test]
+    fn test_detect_license_in_jar_missing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        assert_eq!(
+            detect_license_in_jar(&temp_dir.path().join("does-not-exist.jar")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_fetch_license_from_local_jar_requires_concrete_version() {
+        // Without a concrete version the jar can't be located, so no probing happens.
+        assert_eq!(fetch_license_from_local_jar("g", "a", ""), None);
+        assert_eq!(fetch_license_from_local_jar("g", "a", "RELEASE"), None);
     }
 
     #[test]

--- a/src/languages/node.rs
+++ b/src/languages/node.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    detect_license_from_content, fetch_licenses_from_github, is_license_restrictive,
+    detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
 
@@ -1711,32 +1711,13 @@ fn get_license_from_local_license_file(project_root: &Path, package_name: &str) 
         ]
     };
 
-    let license_filenames = [
-        "LICENSE",
-        "LICENSE.md",
-        "LICENSE.txt",
-        "COPYING",
-        "COPYING.md",
-    ];
-
     for dir in package_dirs {
-        if !dir.exists() {
-            continue;
-        }
-
-        for filename in &license_filenames {
-            let license_path = dir.join(filename);
-            if license_path.exists() {
-                if let Ok(content) = fs::read_to_string(&license_path) {
-                    if !content.trim().is_empty() {
-                        log(
-                            LogLevel::Info,
-                            &format!("Found license file for {package_name}: {filename}"),
-                        );
-                        return detect_license_from_content(&content);
-                    }
-                }
-            }
+        if let Some(license) = detect_license_in_dir(&dir) {
+            log(
+                LogLevel::Info,
+                &format!("Found license file for {package_name} in {}", dir.display()),
+            );
+            return Some(license);
         }
     }
 

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -10,7 +10,7 @@ use toml::Value as TomlValue;
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    detect_license_from_content, fetch_licenses_from_github, is_license_restrictive,
+    detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
 
@@ -490,36 +490,12 @@ fn check_site_package_metadata(site_packages: &Path, package_name: &str) -> Opti
 }
 
 fn check_site_package_license_file(site_packages: &Path, package_name: &str) -> Option<String> {
-    let package_dirs = vec![
+    [
         site_packages.join(package_name),
         site_packages.join(package_name.replace('-', "_")),
-    ];
-
-    let license_files = [
-        "LICENSE",
-        "LICENSE.txt",
-        "LICENSE.md",
-        "COPYING",
-        "COPYING.md",
-    ];
-
-    for package_dir in package_dirs {
-        if !package_dir.exists() {
-            continue;
-        }
-
-        for license_file in &license_files {
-            let license_path = package_dir.join(license_file);
-            if license_path.exists() {
-                if let Ok(content) = fs::read_to_string(&license_path) {
-                    if let Some(license) = detect_license_from_content(&content) {
-                        return Some(license);
-                    }
-                }
-            }
-        }
-    }
-    None
+    ]
+    .iter()
+    .find_map(|package_dir| detect_license_in_dir(package_dir))
 }
 
 fn fetch_license_from_pypi(name: &str, version: &str) -> String {

--- a/src/languages/r.rs
+++ b/src/languages/r.rs
@@ -1,11 +1,14 @@
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
 
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, License, LicenseCompatibility, LicenseInfo,
+    detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive, License,
+    LicenseCompatibility, LicenseInfo,
 };
 
 pub fn analyze_r_licenses(package_file_path: &str, config: &FeludaConfig) -> Vec<LicenseInfo> {
@@ -249,77 +252,107 @@ fn process_dependency_field(field: &str, value: &str, deps: &mut Vec<(String, St
 }
 
 pub fn fetch_license_for_r_dependency(name: &str, version: &str) -> String {
+    if let Some(license) = fetch_license_from_r_universe(name) {
+        return license;
+    }
+
+    // Local fallback: probe the installed package's bundled LICENSE/COPYING files.
+    if let Some(license) = fetch_from_local_r_library(name) {
+        return license;
+    }
+
+    log(
+        LogLevel::Warn,
+        &format!("No license found for {name} ({version})"),
+    );
+    format!("Unknown license for {name}: {version}")
+}
+
+fn fetch_license_from_r_universe(name: &str) -> Option<String> {
     let search_url = format!("https://r-universe.dev/api/search?q={name}&limit=1");
     log(
         LogLevel::Info,
         &format!("Fetching license from R-universe: {search_url}"),
     );
 
-    match reqwest::blocking::get(&search_url) {
-        Ok(response) => {
-            let status = response.status();
-            log(
-                LogLevel::Info,
-                &format!("R-universe API response status: {status}"),
-            );
+    let response = reqwest::blocking::get(&search_url).ok()?;
+    if !response.status().is_success() {
+        log(
+            LogLevel::Error,
+            &format!(
+                "Failed to fetch metadata for {name}: HTTP {}",
+                response.status()
+            ),
+        );
+        return None;
+    }
 
-            if status.is_success() {
-                match response.json::<Value>() {
-                    Ok(json) => {
-                        if let Some(results) = json["results"].as_array() {
-                            if let Some(first_result) = results.first() {
-                                if let Some(user) = first_result["_user"].as_str() {
-                                    let package_url = format!(
-                                        "https://{user}.r-universe.dev/api/packages/{name}"
-                                    );
-                                    log(
-                                        LogLevel::Info,
-                                        &format!("Fetching package details from: {package_url}"),
-                                    );
+    let json = response.json::<Value>().ok()?;
+    let user = json["results"].as_array()?.first()?["_user"].as_str()?;
 
-                                    if let Ok(pkg_response) = reqwest::blocking::get(&package_url) {
-                                        if let Ok(pkg_json) = pkg_response.json::<Value>() {
-                                            if let Some(license) = pkg_json["License"].as_str() {
-                                                if !license.is_empty() {
-                                                    log(
-                                                        LogLevel::Info,
-                                                        &format!(
-                                                            "License found for {name}: {license}"
-                                                        ),
-                                                    );
-                                                    return license.to_string();
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+    let package_url = format!("https://{user}.r-universe.dev/api/packages/{name}");
+    log(
+        LogLevel::Info,
+        &format!("Fetching package details from: {package_url}"),
+    );
 
-                        log(
-                            LogLevel::Warn,
-                            &format!("No license found for {name} ({version})"),
-                        );
-                        format!("Unknown license for {name}: {version}")
-                    }
-                    Err(err) => {
-                        log_error(&format!("Failed to parse JSON for {name}: {version}"), &err);
-                        String::from("Unknown")
-                    }
+    let pkg_json = reqwest::blocking::get(&package_url)
+        .ok()?
+        .json::<Value>()
+        .ok()?;
+    let license = pkg_json["License"].as_str()?;
+    if license.is_empty() {
+        return None;
+    }
+
+    log(
+        LogLevel::Info,
+        &format!("License found for {name}: {license}"),
+    );
+    Some(license.to_string())
+}
+
+/// Probe installed R packages for a bundled license file.
+///
+/// Installed packages live at `<lib>/<name>/`, where the library paths come from R's
+/// `.libPaths()` (via `Rscript`) plus the `R_LIBS_USER`/`R_LIBS`/`R_LIBS_SITE` env vars.
+fn fetch_from_local_r_library(name: &str) -> Option<String> {
+    r_library_paths()
+        .iter()
+        .find_map(|lib| detect_license_in_dir(&lib.join(name)))
+}
+
+/// R library directories, from `.libPaths()` and the standard `R_LIBS*` env vars.
+fn r_library_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Ok(output) = Command::new("Rscript")
+        .args(["-e", "cat(.libPaths(), sep=\"\\n\")"])
+        .output()
+    {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                let line = line.trim();
+                if !line.is_empty() {
+                    paths.push(PathBuf::from(line));
                 }
-            } else {
-                log(
-                    LogLevel::Error,
-                    &format!("Failed to fetch metadata for {name}: HTTP {status}"),
-                );
-                String::from("Unknown")
             }
         }
-        Err(err) => {
-            log_error(&format!("Failed to fetch metadata for {name}"), &err);
-            String::from("Unknown")
+    }
+
+    for var in ["R_LIBS_USER", "R_LIBS", "R_LIBS_SITE"] {
+        if let Ok(value) = std::env::var(var) {
+            for part in value.split([':', ';']) {
+                let path = PathBuf::from(part);
+                if !part.is_empty() && !paths.contains(&path) {
+                    paths.push(path);
+                }
+            }
         }
     }
+
+    paths
 }
 
 #[cfg(test)]
@@ -367,6 +400,26 @@ Suggests:
         let deps = parse_dcf_dependencies(content);
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].0, "dplyr");
+    }
+
+    #[test]
+    fn test_fetch_from_local_r_library_via_env() {
+        // A package name that won't collide with anything actually installed on the machine.
+        let pkg_name = "feludaTestPkg";
+        let temp_dir = TempDir::new().unwrap();
+        let lib_dir = temp_dir.path();
+        let pkg_dir = lib_dir.join(pkg_name);
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(pkg_dir.join("LICENSE"), "MIT License\n\nCopyright (c) 2024").unwrap();
+
+        // R_LIBS_USER points the probe at our temp library directory.
+        temp_env::with_var("R_LIBS_USER", Some(lib_dir.to_str().unwrap()), || {
+            assert_eq!(
+                fetch_from_local_r_library(pkg_name),
+                Some("MIT".to_string())
+            );
+            assert_eq!(fetch_from_local_r_library("feludaNonexistentPkg"), None);
+        });
     }
 
     #[test]

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -3,11 +3,14 @@ use regex::Regex;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use crate::config::FeludaConfig;
 use crate::debug::{log, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+    detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
+    LicenseCompatibility, LicenseInfo,
 };
 
 #[derive(Debug, Clone)]
@@ -189,7 +192,82 @@ fn fetch_ruby_license(name: &str, version: &str) -> String {
         }
     }
 
-    fetch_license_latest(name).unwrap_or_else(|| "Unknown".to_string())
+    if let Some(license) = fetch_license_latest(name) {
+        return license;
+    }
+
+    // Local fallback: probe the installed gem's bundled LICENSE/COPYING files.
+    fetch_from_local_gem(name, version).unwrap_or_else(|| "Unknown".to_string())
+}
+
+/// Probe locally installed gems for a bundled license file.
+///
+/// Gems unpack to `<gem path>/gems/<name>-<version>/`, so we read the gem paths reported by
+/// `gem env gempath` (falling back to `GEM_HOME`) and route each candidate dir through the
+/// shared [`detect_license_in_dir`] engine.
+fn fetch_from_local_gem(name: &str, version: &str) -> Option<String> {
+    for gem_path in gem_paths() {
+        let gems_dir = gem_path.join("gems");
+
+        if !version.is_empty() {
+            let exact = gems_dir.join(format!("{name}-{version}"));
+            if let Some(license) = detect_license_in_dir(&exact) {
+                return Some(license);
+            }
+        }
+
+        if let Some(license) = find_gem_in_any_version(&gems_dir, name) {
+            return Some(license);
+        }
+    }
+    None
+}
+
+/// Gem install roots, from `gem env gempath` (path-separated) plus the `GEM_HOME` env var.
+fn gem_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Ok(output) = Command::new("gem").args(["env", "gempath"]).output() {
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for part in stdout.trim().split([':', ';']) {
+                if !part.is_empty() {
+                    paths.push(PathBuf::from(part));
+                }
+            }
+        }
+    }
+
+    if let Ok(gem_home) = std::env::var("GEM_HOME") {
+        let path = PathBuf::from(gem_home);
+        if !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
+
+    paths
+}
+
+/// Find any installed version of `name` under `gems_dir` and detect its license.
+///
+/// Directories are named `<name>-<version>`; we require the suffix after `<name>-` to start
+/// with a digit so a gem like `rails` doesn't match `rails-html-sanitizer`.
+fn find_gem_in_any_version(gems_dir: &Path, name: &str) -> Option<String> {
+    let prefix = format!("{name}-");
+    let entries = fs::read_dir(gems_dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if let Some(file_name) = path.file_name().and_then(|s| s.to_str()) {
+            if let Some(rest) = file_name.strip_prefix(&prefix) {
+                if rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                    if let Some(license) = detect_license_in_dir(&path) {
+                        return Some(license);
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 fn fetch_license_for_version(name: &str, version: &str) -> Option<String> {
@@ -340,5 +418,40 @@ gem "redis", require: false
     fn test_parse_gemfile_lock_empty() {
         assert!(parse_gemfile_lock("").is_empty());
         assert!(parse_gemfile("").is_empty());
+    }
+
+    #[test]
+    fn test_find_gem_in_any_version_detects_license() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let gems_dir = temp_dir.path().join("gems");
+        let gem_dir = gems_dir.join("nokogiri-1.13.10");
+        fs::create_dir_all(&gem_dir).unwrap();
+        fs::write(gem_dir.join("LICENSE"), "MIT License\n\nCopyright (c) 2024").unwrap();
+
+        assert_eq!(
+            find_gem_in_any_version(&gems_dir, "nokogiri"),
+            Some("MIT".to_string())
+        );
+    }
+
+    #[test]
+    fn test_find_gem_in_any_version_no_name_collision() {
+        // "rails" must not match "rails-html-sanitizer".
+        let temp_dir = tempfile::tempdir().unwrap();
+        let gems_dir = temp_dir.path().join("gems");
+        let other = gems_dir.join("rails-html-sanitizer-1.4.4");
+        fs::create_dir_all(&other).unwrap();
+        fs::write(other.join("LICENSE"), "MIT License").unwrap();
+
+        assert_eq!(find_gem_in_any_version(&gems_dir, "rails"), None);
+    }
+
+    #[test]
+    fn test_find_gem_in_any_version_missing_dir() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            find_gem_in_any_version(&temp_dir.path().join("gems"), "nokogiri"),
+            None
+        );
     }
 }

--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -4,7 +4,8 @@ use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
 use crate::debug::{log, log_debug, log_error, LogLevel};
 use crate::licenses::{
-    fetch_licenses_from_github, is_license_restrictive, LicenseCompatibility, LicenseInfo,
+    detect_license_from_content, detect_license_in_dir, fetch_licenses_from_github,
+    is_license_restrictive, LicenseCompatibility, LicenseInfo,
 };
 
 /// Analyze the licenses of Rust dependencies from Cargo packages
@@ -222,23 +223,53 @@ fn get_license_from_manifest<P: AsRef<std::path::Path>>(manifest_path: P) -> Opt
         return None;
     }
 
-    match fs::read_to_string(manifest_path) {
-        Ok(content) => match toml::from_str::<Value>(&content) {
-            Ok(manifest) => manifest
-                .get("package")
-                .and_then(|pkg| pkg.get("license"))
-                .and_then(|license| license.as_str())
-                .map(|s| {
-                    log(
-                        crate::debug::LogLevel::Info,
-                        &format!("Found license in manifest: {s}"),
-                    );
-                    s.to_string()
-                }),
-            Err(_) => None,
-        },
-        Err(_) => None,
+    let content = fs::read_to_string(manifest_path).ok()?;
+    let manifest = toml::from_str::<Value>(&content).ok()?;
+    let package = manifest.get("package");
+
+    // 1. Explicit SPDX expression in the `license` field.
+    if let Some(license) = package
+        .and_then(|pkg| pkg.get("license"))
+        .and_then(|license| license.as_str())
+    {
+        log(
+            crate::debug::LogLevel::Info,
+            &format!("Found license in manifest: {license}"),
+        );
+        return Some(license.to_string());
     }
+
+    let crate_dir = manifest_path.parent();
+
+    // 2. `license-file` field: a relative path to a bundled license text, which may use a
+    //    non-standard filename (e.g. `LICENSE-MIT`), so read it directly and content-detect.
+    if let (Some(dir), Some(rel)) = (
+        crate_dir,
+        package
+            .and_then(|pkg| pkg.get("license-file"))
+            .and_then(|license_file| license_file.as_str()),
+    ) {
+        if let Ok(text) = fs::read_to_string(dir.join(rel)) {
+            if let Some(spdx) = detect_license_from_content(&text) {
+                log(
+                    crate::debug::LogLevel::Info,
+                    &format!("Detected {spdx} license from license-file: {rel}"),
+                );
+                return Some(spdx);
+            }
+        }
+    }
+
+    // 3. Probe conventional license files (LICENSE, COPYING, …) in the crate root.
+    if let Some(spdx) = crate_dir.and_then(detect_license_in_dir) {
+        log(
+            crate::debug::LogLevel::Info,
+            &format!("Detected {spdx} license from crate license file"),
+        );
+        return Some(spdx);
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -349,5 +380,73 @@ version = "0.1.0"
 
         let result = get_license_from_manifest(&manifest_path);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_get_license_from_manifest_license_file_field() {
+        let temp_dir = TempDir::new().unwrap();
+        let manifest_path = temp_dir.path().join("Cargo.toml");
+
+        // A crate with no `license` field, only a `license-file` pointing at a
+        // non-standard filename — previously this resolved to "No License".
+        let manifest_content = r#"[package]
+name = "test-crate"
+version = "0.1.0"
+license-file = "LICENSE-MIT"
+"#;
+        std::fs::write(&manifest_path, manifest_content).unwrap();
+        std::fs::write(
+            temp_dir.path().join("LICENSE-MIT"),
+            "MIT License\n\nPermission is hereby granted, free of charge, to any person",
+        )
+        .unwrap();
+
+        let result = get_license_from_manifest(&manifest_path);
+        assert_eq!(result, Some("MIT".to_string()));
+    }
+
+    #[test]
+    fn test_get_license_from_manifest_crate_dir_fallback() {
+        let temp_dir = TempDir::new().unwrap();
+        let manifest_path = temp_dir.path().join("Cargo.toml");
+
+        // No `license` and no `license-file` field, but a conventional LICENSE file
+        // ships in the crate root.
+        let manifest_content = r#"[package]
+name = "test-crate"
+version = "0.1.0"
+"#;
+        std::fs::write(&manifest_path, manifest_content).unwrap();
+        std::fs::write(
+            temp_dir.path().join("LICENSE"),
+            "Apache License\nVersion 2.0, January 2004",
+        )
+        .unwrap();
+
+        let result = get_license_from_manifest(&manifest_path);
+        assert_eq!(result, Some("Apache-2.0".to_string()));
+    }
+
+    #[test]
+    fn test_get_license_from_manifest_license_field_wins_over_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let manifest_path = temp_dir.path().join("Cargo.toml");
+
+        // When both are present the explicit SPDX expression takes precedence.
+        let manifest_content = r#"[package]
+name = "test-crate"
+version = "0.1.0"
+license = "MIT"
+license-file = "LICENSE"
+"#;
+        std::fs::write(&manifest_path, manifest_content).unwrap();
+        std::fs::write(
+            temp_dir.path().join("LICENSE"),
+            "Apache License\nVersion 2.0, January 2004",
+        )
+        .unwrap();
+
+        let result = get_license_from_manifest(&manifest_path);
+        assert_eq!(result, Some("MIT".to_string()));
     }
 }

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -1059,6 +1059,15 @@ static LICENSE_FILENAMES: &[LicenseFilename] = &[
         filename: "COPYING",
         implied_spdx: None,
     },
+    LicenseFilename {
+        filename: "COPYING.md",
+        implied_spdx: None,
+    },
+    // `copyright` is the Debian/vcpkg convention (e.g. /usr/share/doc/<pkg>/copyright).
+    LicenseFilename {
+        filename: "copyright",
+        implied_spdx: None,
+    },
     // OFL.txt is the conventional license file for font projects (e.g. Google Fonts).
     LicenseFilename {
         filename: "OFL.txt",
@@ -1178,6 +1187,41 @@ pub fn detect_license_from_content(content: &str) -> Option<String> {
     match_license_content(content).map(str::to_string)
 }
 
+/// Probe a directory for a conventional license file (`LICENSE`, `COPYING`, …) and return
+/// its canonical SPDX id, or `None` if no recognizable license file is found.
+///
+/// This is the directory-level companion to [`detect_license_from_content`]: every language
+/// analyzer's local-license-file fallback routes through it, so the filename list and the
+/// filename → SPDX shortcuts (e.g. `OFL.txt` → `OFL-1.1`) stay defined in exactly one place.
+pub fn detect_license_in_dir(dir: &Path) -> Option<String> {
+    for entry in LICENSE_FILENAMES {
+        let license_path = dir.join(entry.filename);
+        if !license_path.exists() {
+            continue;
+        }
+
+        // Filename alone is sufficient (e.g. OFL.txt → OFL-1.1).
+        if let Some(spdx) = entry.implied_spdx {
+            return Some(spdx.to_string());
+        }
+
+        match fs::read_to_string(&license_path) {
+            Ok(content) => {
+                if let Some(spdx) = match_license_content(&content) {
+                    return Some(spdx.to_string());
+                }
+            }
+            Err(err) => {
+                log_debug(
+                    &format!("Failed to read license file: {}", license_path.display()),
+                    &err,
+                );
+            }
+        }
+    }
+    None
+}
+
 /// Detect the project's license
 pub fn detect_project_license(project_path: &str) -> FeludaResult<Option<String>> {
     log(
@@ -1185,45 +1229,12 @@ pub fn detect_project_license(project_path: &str) -> FeludaResult<Option<String>
         &format!("Detecting license for project at path: {project_path}"),
     );
 
-    for entry in LICENSE_FILENAMES {
-        let license_path = Path::new(project_path).join(entry.filename);
-        if !license_path.exists() {
-            continue;
-        }
-
+    if let Some(spdx) = detect_license_in_dir(Path::new(project_path)) {
         log(
             LogLevel::Info,
-            &format!("Found license file: {}", license_path.display()),
+            &format!("Detected {spdx} license from project license file"),
         );
-
-        // Filename alone is sufficient (e.g. OFL.txt → OFL-1.1).
-        if let Some(spdx) = entry.implied_spdx {
-            log(
-                LogLevel::Info,
-                &format!("Detected {spdx} license from filename"),
-            );
-            return Ok(Some(spdx.to_string()));
-        }
-
-        match fs::read_to_string(&license_path) {
-            Ok(content) => {
-                if let Some(spdx) = match_license_content(&content) {
-                    log(LogLevel::Info, &format!("Detected {spdx} license"));
-                    return Ok(Some(spdx.to_string()));
-                }
-                log(
-                    LogLevel::Warn,
-                    "License file found but could not determine license type",
-                );
-            }
-            Err(err) => {
-                log(
-                    LogLevel::Error,
-                    &format!("Failed to read license file: {}", license_path.display()),
-                );
-                log_debug("Error details", &err);
-            }
-        }
+        return Ok(Some(spdx));
     }
 
     // Check package.json for Node.js projects
@@ -1600,5 +1611,50 @@ mod tests {
     #[test]
     fn test_detect_license_from_content_no_match() {
         assert_eq!(detect_license_from_content("Some random content"), None);
+    }
+
+    #[test]
+    fn test_detect_license_in_dir_content() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("LICENSE"),
+            "Apache License\nVersion 2.0, January 2004",
+        )
+        .unwrap();
+        assert_eq!(
+            detect_license_in_dir(dir.path()),
+            Some("Apache-2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_license_in_dir_implied_from_filename() {
+        // OFL.txt resolves from the filename alone, even with empty content.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("OFL.txt"), "").unwrap();
+        assert_eq!(
+            detect_license_in_dir(dir.path()),
+            Some("OFL-1.1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_license_in_dir_copying() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("COPYING"),
+            "GNU GENERAL PUBLIC LICENSE\nVersion 3, 29 June 2007",
+        )
+        .unwrap();
+        assert_eq!(
+            detect_license_in_dir(dir.path()),
+            Some("GPL-3.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_license_in_dir_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(detect_license_in_dir(dir.path()), None);
     }
 }


### PR DESCRIPTION
Only Node, Go, and Python scanned a dependency's bundled license files; every other ecosystem relied solely on registry/manifest metadata. When that metadata was absent the dependency resolved to "No License" or "Unknown" even though a `LICENSE` file sat right there on disk — e.g. a Rust crate that ships only a `license-file`, or a Maven jar whose license text lives in `META-INF/LICENSE`.

Add `detect_license_in_dir`, a directory-level companion to `detect_license_from_content`, and route every analyzer through it as a fallback after registry lookups:

  - Rust: honor the `license-file` field, then probe the crate root
  - .NET: probe `~/.nuget/packages/...`; also fixes `<license type="file">` reporting the literal filename instead of the license
  - Ruby: locate gems via `gem env gempath`
  - R: locate packages via `Rscript .libPaths()` and `R_LIBS*`
  - C: read `/usr/share/doc/<pkg>/copyright`
  - C++: read vcpkg `installed/<triplet>/share/<port>/copyright`
  - Java: extract `META-INF/LICENSE` from the cached jar in `~/.m2`

The existing Node/Go/Python fallbacks are retrofitted onto the shared helper, removing three duplicated filename-probing loops. Detection is strictly a fallback: registry and manifest results keep priority, so results only improve where they were previously unresolved.

Java jar extraction needs Zip support; `zip` is added with default features disabled (deflate only). Conan is intentionally left out — its content-addressed cache can't be mapped to a package name without the `conan` CLI.