### PR TITLE
fix(licenses): offline license text and copyleft restrictiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ A **THIRD_PARTY_LICENSES file** provides comprehensive license documentation:
 
 - **Purpose**: Complete legal documentation for all dependencies
 - **Content**: Full license texts, compatibility analysis, package URLs, and copyright information
+- **Offline-friendly**: Reads full license text from your local package caches (Cargo `registry/src`, Go module cache, `node_modules`, Python `site-packages`) first, falling back to the network only when a package isn't cached locally — so it works on locked-down or air-gapped machines
 - **Use Cases**:
   - Commercial software distribution requirements
   - Legal compliance for enterprise applications

--- a/docs/source/cli/generate.rst
+++ b/docs/source/cli/generate.rst
@@ -96,6 +96,15 @@ Generated Files
 
 ----
 
+License Text Sources
+--------------------
+
+For ``THIRD_PARTY_LICENSES``, Feluda reads each dependency's full license text from your local toolchain caches first — the Go module cache, Cargo ``registry/src``, Python ``site-packages``, and the project's ``node_modules`` — and only falls back to the network (crates.io, npm, PyPI, the Go proxy, GitHub) when a package isn't cached locally.
+
+Because the dependencies were already downloaded to build the project, their license files are on disk, so generation works on locked-down or offline workstations instead of leaving entries blank. Populated caches also make generation faster.
+
+----
+
 CI/CD Usage
 -----------
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1,7 +1,8 @@
 use crate::cli::with_spinner;
 use crate::debug::{log, log_debug, LogLevel};
 use crate::licenses::{
-    detect_project_license, is_license_compatible, LicenseCompatibility, LicenseInfo,
+    detect_project_license, is_license_compatible, read_license_text_in_dir, LicenseCompatibility,
+    LicenseInfo,
 };
 use crate::parser::parse_root;
 use colored::*;
@@ -11,7 +12,7 @@ use std::io::{self, Write};
 use std::io::{stdin, Read};
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 /// Key input handling for cross-platform compatibility
@@ -535,7 +536,7 @@ pub fn generate_third_party_licenses_file(license_data: &[LicenseInfo], path: &s
             "Fetching license content for {} dependencies",
             license_data.len()
         ),
-        |indicator| generate_third_party_licenses_content(license_data, indicator),
+        |indicator| generate_third_party_licenses_content(license_data, Path::new(path), indicator),
     );
 
     // Write to file
@@ -599,12 +600,158 @@ fn rate_limit_delay() {
     std::thread::sleep(Duration::from_millis(500));
 }
 
+/// Read a dependency's license text from the local toolchain caches, without any network access.
+///
+/// Probes each ecosystem's on-disk cache in turn and returns the first license file found.
+/// [`LicenseInfo`] carries no ecosystem tag, so — like the network path — we try each source and
+/// take the first hit; a cache directory only exists for the ecosystem that actually installed
+/// the package, so cross-ecosystem name collisions are effectively impossible in practice.
+fn fetch_license_from_local_cache(
+    name: &str,
+    version: &str,
+    project_root: &Path,
+) -> Option<String> {
+    // Go module cache: $GOMODCACHE/<escaped-module>@<version>/
+    if let Some(text) = local_license_from_go_cache(name, version) {
+        return Some(text);
+    }
+    // Cargo registry sources: $CARGO_HOME/registry/src/<index>/<name>-<version>/
+    if let Some(text) = local_license_from_cargo_cache(name, version) {
+        return Some(text);
+    }
+    // Python site-packages: <site-packages>/<name>/ or <name>-<version>.dist-info/
+    if let Some(text) = local_license_from_python_cache(name, version) {
+        return Some(text);
+    }
+    // Node modules: <project>/node_modules/<name>/
+    if let Some(text) = local_license_from_node_modules(name, project_root) {
+        return Some(text);
+    }
+    None
+}
+
+/// Locate a Go module in the local module cache and read its license text.
+///
+/// Reuses the same cache-path resolution and case-escaping the Go analyzer uses, so the two stay
+/// in lockstep. Go module paths always contain a slash (e.g. `github.com/gin-gonic/gin`), which
+/// cheaply rules out non-Go names before touching the filesystem.
+fn local_license_from_go_cache(name: &str, version: &str) -> Option<String> {
+    if !name.contains('/') {
+        return None;
+    }
+
+    let cache = crate::languages::go::get_gomodcache_path()?;
+
+    let exact = crate::languages::go::build_module_cache_path(&cache, name, version);
+    if let Some(text) = read_license_text_in_dir(&exact) {
+        return Some(text);
+    }
+
+    // The requested version may not be cached (e.g. a replace directive); fall back to any
+    // cached version of the same module.
+    let prefix = format!("{}@", crate::languages::go::escape_go_module_path(name));
+    for entry in fs::read_dir(&cache).ok()?.flatten() {
+        let path = entry.path();
+        let is_match = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with(&prefix));
+        if is_match {
+            if let Some(text) = read_license_text_in_dir(&path) {
+                return Some(text);
+            }
+        }
+    }
+
+    None
+}
+
+/// Locate a crate in the local Cargo registry cache and read its license text.
+///
+/// `registry/src` holds one subdirectory per registry index (e.g. `index.crates.io-<hash>`), so
+/// we scan each for a `<name>-<version>` crate source directory.
+fn local_license_from_cargo_cache(name: &str, version: &str) -> Option<String> {
+    let src_root = cargo_home_dir()?.join("registry").join("src");
+    let crate_dir = format!("{name}-{version}");
+
+    for entry in fs::read_dir(&src_root).ok()?.flatten() {
+        let candidate = entry.path().join(&crate_dir);
+        if candidate.is_dir() {
+            if let Some(text) = read_license_text_in_dir(&candidate) {
+                return Some(text);
+            }
+        }
+    }
+
+    None
+}
+
+/// Resolve `CARGO_HOME`, falling back to `~/.cargo` (mirroring Cargo's own default).
+fn cargo_home_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("CARGO_HOME") {
+        return Some(PathBuf::from(dir));
+    }
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    Some(PathBuf::from(home).join(".cargo"))
+}
+
+/// Locate a Python package in the local site-packages and read its license text.
+///
+/// Tries the importable package directory (with the usual `-`/`_` normalization) and the wheel
+/// metadata directory (`<name>-<version>.dist-info/`), which is where `pip` drops the bundled
+/// `LICENSE` file.
+fn local_license_from_python_cache(name: &str, version: &str) -> Option<String> {
+    let underscored = name.replace('-', "_");
+
+    for site in crate::languages::python::get_python_site_packages_paths() {
+        let candidates = [
+            site.join(name),
+            site.join(&underscored),
+            site.join(format!("{name}-{version}.dist-info")),
+            site.join(format!("{underscored}-{version}.dist-info")),
+        ];
+        for dir in candidates {
+            if dir.is_dir() {
+                if let Some(text) = read_license_text_in_dir(&dir) {
+                    return Some(text);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Locate a Node package in the project's `node_modules` and read its license text.
+///
+/// Scoped names (`@scope/pkg`) map to `node_modules/@scope/pkg`, which `Path::join` produces
+/// correctly from the slash in the name.
+fn local_license_from_node_modules(name: &str, project_root: &Path) -> Option<String> {
+    let dir = project_root.join("node_modules").join(name);
+    if dir.is_dir() {
+        return read_license_text_in_dir(&dir);
+    }
+    None
+}
+
 /// Fetch the actual license content for a dependency
-fn fetch_actual_license_content(name: &str, version: &str) -> Option<String> {
+fn fetch_actual_license_content(name: &str, version: &str, project_root: &Path) -> Option<String> {
     log(
         LogLevel::Info,
         &format!("Attempting to fetch actual license content for {name} v{version}"),
     );
+
+    // Prefer license text already present in the local toolchain caches. It's faster than any
+    // network round-trip and, crucially, is the only source that works on locked-down/offline
+    // workstations where every registry and GitHub request fails (issue #191). The dependency
+    // had to be downloaded to build, so its license file is already on disk.
+    if let Some(content) = fetch_license_from_local_cache(name, version, project_root) {
+        log(
+            LogLevel::Info,
+            &format!("Using local cache license text for {name} v{version}"),
+        );
+        return Some(content);
+    }
 
     // Fetch from crates.io for Rust packages
     if let Some(content) = fetch_license_from_crates_io(name, version) {
@@ -916,6 +1063,7 @@ fn fetch_license_from_github_repo(repo_url: &str) -> Option<String> {
 /// Generate the content for a THIRD_PARTY_LICENSES file
 fn generate_third_party_licenses_content(
     license_data: &[LicenseInfo],
+    project_root: &Path,
     indicator: &crate::cli::LoadingIndicator,
 ) -> (String, (usize, usize)) {
     let mut content = String::new();
@@ -987,7 +1135,7 @@ fn generate_third_party_licenses_content(
         content.push_str("\n### License Text\n\n");
 
         // Try to fetch the actual license content
-        match fetch_actual_license_content(&dep.name, &dep.version) {
+        match fetch_actual_license_content(&dep.name, &dep.version, project_root) {
             Some(actual_license_content) => {
                 successfully_fetched += 1;
                 log(
@@ -1865,7 +2013,52 @@ mod tests {
     #[test]
     fn test_fetch_actual_license_content_invalid_package() {
         // This should return None for invalid packages
-        let result = fetch_actual_license_content("definitely_nonexistent_package_12345", "1.0.0");
+        let result = fetch_actual_license_content(
+            "definitely_nonexistent_package_12345",
+            "1.0.0",
+            Path::new("."),
+        );
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_local_license_from_node_modules_reads_license_file() {
+        let temp = TempDir::new().unwrap();
+        let pkg_dir = temp.path().join("node_modules").join("left-pad");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(pkg_dir.join("LICENSE"), "The MIT License\n\nCopyright (c)").unwrap();
+
+        let text = local_license_from_node_modules("left-pad", temp.path());
+        assert!(text.is_some());
+        assert!(text.unwrap().contains("MIT License"));
+    }
+
+    #[test]
+    fn test_local_license_from_node_modules_scoped_package() {
+        let temp = TempDir::new().unwrap();
+        let pkg_dir = temp.path().join("node_modules").join("@scope").join("pkg");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(pkg_dir.join("LICENSE"), "Apache License\nVersion 2.0").unwrap();
+
+        let text = local_license_from_node_modules("@scope/pkg", temp.path());
+        assert!(text.is_some());
+        assert!(text.unwrap().contains("Apache License"));
+    }
+
+    #[test]
+    fn test_local_license_from_node_modules_missing_returns_none() {
+        let temp = TempDir::new().unwrap();
+        assert!(local_license_from_node_modules("absent", temp.path()).is_none());
+    }
+
+    #[test]
+    fn test_fetch_license_from_local_cache_prefers_node_modules() {
+        let temp = TempDir::new().unwrap();
+        let pkg_dir = temp.path().join("node_modules").join("some-pkg");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(pkg_dir.join("LICENSE"), "BSD 3-Clause License").unwrap();
+
+        let text = fetch_license_from_local_cache("some-pkg", "1.0.0", temp.path());
+        assert_eq!(text.as_deref(), Some("BSD 3-Clause License"));
     }
 }

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -663,7 +663,7 @@ fn get_license_from_go_module_cache(package_name: &str, version: &str) -> Option
     find_license_in_any_version(&module_cache, package_name)
 }
 
-fn get_gomodcache_path() -> Option<PathBuf> {
+pub(crate) fn get_gomodcache_path() -> Option<PathBuf> {
     if let Ok(output) = Command::new("go").args(["env", "GOMODCACHE"]).output() {
         if output.status.success() {
             let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -689,7 +689,7 @@ fn get_gomodcache_path() -> Option<PathBuf> {
     }
 }
 
-fn escape_go_module_path(module: &str) -> String {
+pub(crate) fn escape_go_module_path(module: &str) -> String {
     let mut escaped = String::with_capacity(module.len());
     for ch in module.chars() {
         match ch {
@@ -704,7 +704,7 @@ fn escape_go_module_path(module: &str) -> String {
     escaped
 }
 
-fn build_module_cache_path(root: &Path, module: &str, version: &str) -> PathBuf {
+pub(crate) fn build_module_cache_path(root: &Path, module: &str, version: &str) -> PathBuf {
     let escaped = escape_go_module_path(module);
     root.join(format!("{escaped}@{version}"))
 }

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -407,7 +407,7 @@ fn get_license_from_local_site_packages(package_name: &str) -> Option<String> {
     None
 }
 
-fn get_python_site_packages_paths() -> Vec<std::path::PathBuf> {
+pub(crate) fn get_python_site_packages_paths() -> Vec<std::path::PathBuf> {
     let mut paths = Vec::new();
 
     if let Ok(output) = Command::new("python3")

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -1385,6 +1385,70 @@ pub fn detect_license_in_dir(dir: &Path) -> Option<String> {
     detect_spdx_header_in_dir(dir)
 }
 
+/// Read the raw text of the first license file found in `dir`, or `None` if the directory has no
+/// readable license file.
+///
+/// This is the text-returning companion to [`detect_license_in_dir`]: that function resolves a
+/// canonical SPDX id, whereas this one returns the verbatim license text for inclusion in a
+/// generated `THIRD_PARTY_LICENSES` document. It first tries the canonical [`LICENSE_FILENAMES`]
+/// in priority order, then falls back to scanning for variant filenames — dual-licensed crates
+/// routinely ship `LICENSE-MIT`/`LICENSE-APACHE`, and others use `LICENCE`, `LICENSE.rst`,
+/// `COPYING.LESSER`, etc. Empty/whitespace-only files are skipped so a stray placeholder doesn't
+/// shadow a real license.
+pub fn read_license_text_in_dir(dir: &Path) -> Option<String> {
+    for entry in LICENSE_FILENAMES {
+        let license_path = dir.join(entry.filename);
+        match fs::read_to_string(&license_path) {
+            Ok(content) if !content.trim().is_empty() => return Some(content),
+            _ => continue,
+        }
+    }
+
+    // Fallback: scan the directory for variant license filenames the canonical list misses.
+    let mut candidates: Vec<PathBuf> = fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file() && looks_like_license_file(path))
+        .collect();
+    // Deterministic order so a fixed choice is made among e.g. LICENSE-APACHE / LICENSE-MIT.
+    candidates.sort();
+
+    for path in candidates {
+        match fs::read_to_string(&path) {
+            Ok(content) if !content.trim().is_empty() => return Some(content),
+            _ => continue,
+        }
+    }
+
+    None
+}
+
+/// Whether a path's filename looks like a license file (`LICENSE*`, `LICENCE*`, `COPYING*`),
+/// excluding source files so we never mistake code (e.g. `license.go`) for license text.
+fn looks_like_license_file(path: &Path) -> bool {
+    const CODE_EXTENSIONS: &[&str] = &[
+        "rs", "go", "py", "js", "ts", "c", "h", "cpp", "cc", "hpp", "java", "rb", "cs", "php",
+        "sh", "toml", "json", "yaml", "yml", "lock",
+    ];
+
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        if CODE_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()) {
+            return false;
+        }
+    }
+
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| {
+            let upper = name.to_ascii_uppercase();
+            upper.starts_with("LICENSE")
+                || upper.starts_with("LICENCE")
+                || upper.starts_with("COPYING")
+        })
+        .unwrap_or(false)
+}
+
 /// Detect the project's license
 pub fn detect_project_license(project_path: &str) -> FeludaResult<Option<String>> {
     log(
@@ -1819,6 +1883,62 @@ mod tests {
     fn test_detect_license_in_dir_none() {
         let dir = tempfile::tempdir().unwrap();
         assert_eq!(detect_license_in_dir(dir.path()), None);
+    }
+
+    #[test]
+    fn test_read_license_text_in_dir_returns_raw_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "MIT License\n\nCopyright (c) 2026 Someone\n\nPermission is hereby granted";
+        fs::write(dir.path().join("LICENSE"), body).unwrap();
+        assert_eq!(read_license_text_in_dir(dir.path()).as_deref(), Some(body));
+    }
+
+    #[test]
+    fn test_read_license_text_in_dir_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(read_license_text_in_dir(dir.path()), None);
+    }
+
+    #[test]
+    fn test_read_license_text_in_dir_skips_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        // An empty LICENSE must not shadow a real COPYING further down the priority list.
+        fs::write(dir.path().join("LICENSE"), "   \n\t\n").unwrap();
+        fs::write(dir.path().join("COPYING"), "GNU GENERAL PUBLIC LICENSE").unwrap();
+        assert_eq!(
+            read_license_text_in_dir(dir.path()).as_deref(),
+            Some("GNU GENERAL PUBLIC LICENSE")
+        );
+    }
+
+    #[test]
+    fn test_read_license_text_in_dir_variant_filenames() {
+        // Dual-licensed crates (e.g. serde) ship LICENSE-APACHE / LICENSE-MIT, which the
+        // canonical filename list doesn't contain; the fallback scan must find them.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("LICENSE-APACHE"),
+            "Apache License\nVersion 2.0",
+        )
+        .unwrap();
+        fs::write(dir.path().join("LICENSE-MIT"), "MIT License").unwrap();
+        // Sorted order picks LICENSE-APACHE deterministically.
+        assert_eq!(
+            read_license_text_in_dir(dir.path()).as_deref(),
+            Some("Apache License\nVersion 2.0")
+        );
+    }
+
+    #[test]
+    fn test_read_license_text_in_dir_ignores_source_files() {
+        // A source file named license.go must never be returned as license text.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("license.go"),
+            "package main\n// not a license",
+        )
+        .unwrap();
+        assert_eq!(read_license_text_in_dir(dir.path()), None);
     }
 
     #[test]

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -601,19 +601,21 @@ fn is_single_license_restrictive(
     strict: bool,
 ) -> bool {
     if let Some(license_data) = known_licenses.get(license_str) {
-        let conditions = if strict {
-            vec![
-                "source-disclosure",
-                "network-use-disclosure",
-                "disclose-source",
-                "same-license",
-            ]
+        // Match against GitHub/choosealicense.com's own `conditions` vocabulary. These keys must
+        // be spelled exactly as the API emits them — the correct key is `disclose-source`, NOT
+        // `source-disclosure` (a non-existent key that silently matched nothing, so copyleft
+        // licenses present in the registry were classified as non-restrictive; issue #31):
+        //   - `disclose-source`        → strong copyleft source disclosure (GPL family)
+        //   - `network-use-disclosure` → network/SaaS copyleft (AGPL)
+        //   - `same-license`           → share-alike / weak copyleft (LGPL, MPL, EPL); strict only
+        let restrictive_conditions: &[&str] = if strict {
+            &["disclose-source", "network-use-disclosure", "same-license"]
         } else {
-            vec!["source-disclosure", "network-use-disclosure"]
+            &["disclose-source", "network-use-disclosure"]
         };
-        return conditions
+        return restrictive_conditions
             .iter()
-            .any(|&c| license_data.conditions.contains(&c.to_string()));
+            .any(|&c| license_data.conditions.iter().any(|cond| cond == c));
     }
 
     let is_restrictive = config
@@ -1939,6 +1941,103 @@ mod tests {
         )
         .unwrap();
         assert_eq!(read_license_text_in_dir(dir.path()), None);
+    }
+
+    fn license_with_conditions(spdx: &str, conditions: &[&str]) -> License {
+        License {
+            title: spdx.to_string(),
+            spdx_id: spdx.to_string(),
+            permissions: Vec::new(),
+            conditions: conditions.iter().map(|c| c.to_string()).collect(),
+            limitations: Vec::new(),
+        }
+    }
+
+    fn registry_with(entries: &[(&str, &[&str])]) -> HashMap<String, License> {
+        entries
+            .iter()
+            .map(|(spdx, conds)| (spdx.to_string(), license_with_conditions(spdx, conds)))
+            .collect()
+    }
+
+    #[test]
+    fn test_registry_gpl_is_restrictive_in_default_mode() {
+        // Regression for #31: a GPL-family license present in the registry was classified as
+        // non-restrictive in the default (non-strict) mode because the code matched a
+        // non-existent condition key (`source-disclosure`). GitHub reports GPL-3.0 with the
+        // real key `disclose-source`.
+        let registry = registry_with(&[(
+            "GPL-3.0",
+            &[
+                "include-copyright",
+                "document-changes",
+                "disclose-source",
+                "same-license",
+            ],
+        )]);
+        assert!(is_license_restrictive(
+            &Some("GPL-3.0".to_string()),
+            &registry,
+            false
+        ));
+        assert!(is_license_restrictive(
+            &Some("GPL-3.0".to_string()),
+            &registry,
+            true
+        ));
+    }
+
+    #[test]
+    fn test_registry_agpl_is_restrictive_via_network_disclosure() {
+        let registry = registry_with(&[(
+            "AGPL-3.0",
+            &[
+                "include-copyright",
+                "disclose-source",
+                "network-use-disclosure",
+                "same-license",
+            ],
+        )]);
+        assert!(is_license_restrictive(
+            &Some("AGPL-3.0".to_string()),
+            &registry,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_registry_permissive_not_restrictive() {
+        let registry = registry_with(&[
+            ("MIT", &["include-copyright"]),
+            ("Apache-2.0", &["include-copyright", "document-changes"]),
+        ]);
+        assert!(!is_license_restrictive(
+            &Some("MIT".to_string()),
+            &registry,
+            false
+        ));
+        assert!(!is_license_restrictive(
+            &Some("Apache-2.0".to_string()),
+            &registry,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_registry_share_alike_only_restrictive_in_strict_mode() {
+        // A share-alike license carrying no source-disclosure obligation is treated as
+        // restrictive only under strict mode.
+        let registry = registry_with(&[("CC-BY-SA-4.0", &["include-copyright", "same-license"])]);
+        assert!(!is_license_restrictive(
+            &Some("CC-BY-SA-4.0".to_string()),
+            &registry,
+            false
+        ));
+        assert!(is_license_restrictive(
+            &Some("CC-BY-SA-4.0".to_string()),
+            &registry,
+            true
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes two independent license-resolution bugs:

1. `THIRD_PARTY_LICENSES` generation now populates real license text on
   offline/locked-down machines instead of leaving entries blank (#191).
2. Copyleft licenses resolved from the GitHub licenses registry are once
   again flagged as restrictive in the default mode (#31).

They're unrelated in mechanism but both concern how licenses are resolved
when the network/registry is involved, and are bundled here as a single
review.

## Motivation

**#191 — empty license details.** `THIRD_PARTY_LICENSES` fetched each
dependency's license text only over the network (crates.io, npm, PyPI, the
Go proxy, GitHub). On a restricted or air-gapped workstation every request
fails, so entries fell back to generic templates or were left blank — the
exact scenario reported in the issue (21/52 texts fetched).

**#31 — registry "empty matches".** Restrictiveness for a license present
in the registry is decided from its `conditions` list. The default
(non-strict) check looked for `source-disclosure` — a key GitHub never
emits; the real key is `disclose-source`. Copyleft licenses that resolved
from the registry (GPL-3.0, LGPL-3.0, MPL-2.0, EPL-2.0) matched nothing and
were classified non-restrictive, and the early return skipped the config
keyword fallback that would otherwise have caught them. The result was an
online/offline inversion: offline the registry was empty and GPL fell
through to the config list (correct), but once the registry loaded GPL was
silently passed (wrong).

## Changes

**#191 — local-first license text**
- Add `read_license_text_in_dir` in `src/licenses.rs`, a text-returning
  companion to `detect_license_in_dir` (which only yields an SPDX id). It
  also handles variant filenames the canonical list misses (`LICENSE-MIT`,
  `LICENSE-APACHE`, `LICENCE`, `COPYING.LESSER`), skipping source files so
  code is never mistaken for license text.
- Add a local-cache resolver in `src/generate.rs` probing the Go module
  cache, Cargo `registry/src`, Python `site-packages`, and the project's
  `node_modules`.
- `fetch_actual_license_content` now reads local caches first, then falls
  back to the existing network fetchers.
- Expose the existing Go/Python cache-path helpers as `pub(crate)` so the
  resolver reuses them rather than duplicating path logic.

**#31 — correct condition vocabulary**
- Match GitHub/choosealicense.com's actual `conditions` keys in
  `is_single_license_restrictive`: non-strict flags `disclose-source` /
  `network-use-disclosure`; strict additionally flags `same-license`
  (share-alike). Removes the phantom `source-disclosure` key.

**Docs**
- New "License Text Sources" section in the `generate` command reference and
  an offline-friendly note in the README.

## Testing

- 13 new unit tests; full suite is 445 passing, `clippy -D warnings` and
  `cargo fmt --check` clean (all enforced by the repo's pre-commit hook,
  which ran green on every commit).
- `read_license_text_in_dir`: raw text, `LICENSE-MIT`/`LICENSE-APACHE`
  variants, empty-file skip, source-file exclusion.
- Local-cache resolver: `node_modules` (incl. scoped `@scope/pkg`), missing
  dir, and source precedence.
- Registry restrictiveness: GPL/AGPL restrictive, MIT/Apache permissive, and
  the strict-only share-alike boundary — the GPL case fails without the #31
  fix.
- Verified end-to-end against real state: read serde's actual `LICENSE-APACHE`
  from this machine's `~/.cargo` cache, and confirmed via the live GitHub API
  that GPL-3.0 reports `conditions: [..., "disclose-source", "same-license"]`.

## Related

Fixes #191
Fixes #31
