### PR TITLE
docs: surface the github action and open community channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,31 @@
 # Feluda
 
-[![Crates.io Version](https://img.shields.io/crates/v/feluda)](https://crates.io/crates/feluda) [![Crates.io Downloads](https://img.shields.io/crates/d/feluda)](https://crates.io/crates/feluda) [![Crates.io Downloads (latest version)](https://img.shields.io/crates/dv/feluda)](https://crates.io/crates/feluda) [![Documentation](https://img.shields.io/badge/docs-feluda-blue)](https://feluda.readthedocs.io/) [![Open Source](https://img.shields.io/badge/open-source-brightgreen)](https://github.com/anistark/feluda) [![Contributors](https://img.shields.io/github/contributors/anistark/feluda)](https://github.com/anistark/feluda/graphs/contributors) ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
+[![Crates.io Version](https://img.shields.io/crates/v/feluda)](https://crates.io/crates/feluda) [![Crates.io Downloads](https://img.shields.io/crates/d/feluda)](https://crates.io/crates/feluda) [![Crates.io Downloads (latest version)](https://img.shields.io/crates/dv/feluda)](https://crates.io/crates/feluda) [![Documentation](https://img.shields.io/badge/docs-feluda-blue)](https://feluda.readthedocs.io/) [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Feluda%20License%20Scanner-2088FF?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/feluda-license-scanner) [![Discord](https://img.shields.io/badge/Discord-Null%20Order-5865F2?logo=discord&logoColor=white)](https://discord.gg/AJMEeFXxXy) [![Open Source](https://img.shields.io/badge/open-source-brightgreen)](https://github.com/anistark/feluda) [![Contributors](https://img.shields.io/github/contributors/anistark/feluda)](https://github.com/anistark/feluda/graphs/contributors) ![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 🔎 **Feluda** is a Rust-based command-line tool that analyzes the dependencies of a project, notes down their licenses, and flags any permissions that restrict personal or commercial usage or are incompatible with your project's license.
 
 ![ss](https://github.com/user-attachments/assets/473908eb-43cb-4c4f-86aa-017de251afa8)
 
 > 👋 It's still highly experimental, but fast iterating. Welcoming contributors and support to help bring out this project even better!
+
+## Quick Start
+
+Scan your project locally:
+
+```sh
+cargo install feluda
+feluda
+```
+
+Or gate your CI on license compliance with the [GitHub Action](https://github.com/marketplace/actions/feluda-license-scanner), no install needed:
+
+```yaml
+- uses: anistark/feluda@v1
+  with:
+    fail-on-restrictive: true
+```
+
+See [Installation](#installation) for more ways to install, and [CI/CD Integration](#cicd-integration) for the full Action reference.
 
 ## Installation
 
@@ -587,7 +606,7 @@ Restrictive licenses are reported at `warning` level; licenses incompatible with
 
 ### GitHub Actions
 
-To use Feluda with GitHub Actions, simply use the published action. For detailed documentation, see the [GitHub Action README](./ACTION-README.md).
+To use Feluda with GitHub Actions, simply use the published action, available on the [GitHub Marketplace](https://github.com/marketplace/actions/feluda-license-scanner) as **Feluda License Scanner**. For detailed documentation, see the [GitHub Action README](./ACTION-README.md).
 
 ```yaml
 name: License Check
@@ -848,6 +867,15 @@ Advanced users can customize compatibility rules by:
 2. **Project-specific rules**: The local `config/license_compatibility.toml` takes precedence
 
 **Important**: Modifying compatibility rules requires legal expertise. Consult legal counsel before making changes that could affect your project's compliance.
+
+## 💬 Using Feluda? Talk to Us
+
+Feluda's roadmap is shaped by how people actually use it. If it's part of your workflow (local scans, CI gates, SBOMs, or something we never imagined), we'd genuinely love to hear about it:
+
+- 🗣️ [Open an issue](https://github.com/anistark/feluda/issues/new) to share your use case, pain points, or feature requests. Even a quick "we use Feluda for X" note helps a lot
+- 🎮 [Join the Null Order Discord](https://discord.gg/AJMEeFXxXy) to chat with us directly
+- 💬 DM [@kranirudha on X](https://x.com/kranirudha) or [@ani on Mastodon](https://fosstodon.org/@ani)
+- 🏷️ Add the [Scanned with Feluda badge](#usage) to your README so others can discover it too
 
 ## ⚠️ Legal Disclaimer
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,13 @@ Each section ends with practical next steps so you can move from manual spot che
 
       View Feluda on crates.io - the Rust package registry.
 
+   .. grid-item-card:: ⚡ GitHub Action
+      :class-card: glassmorphic
+      :link: integrations/github-actions
+      :link-type: doc
+
+      Gate CI on license compliance in 3 lines, no install needed. Available on the GitHub Marketplace.
+
    .. grid-item-card:: 🤝 Contribute to Feluda
       :class-card: glassmorphic
       :link: contributing/index
@@ -61,6 +68,15 @@ Each section ends with practical next steps so you can move from manual spot che
    - **Complexity**: License compatibility can depend on specific use cases, distribution methods, and jurisdictions
 
    Feluda is in active development. While we strive to provide accurate information, **use at your own risk.**
+
+Talk to Us 💬
+-------------
+
+Using Feluda in your project or company? The roadmap is shaped by real investigations, and every case report counts.
+Tell us how you use it: `join the Null Order Discord <https://discord.gg/AJMEeFXxXy>`_,
+`open an issue <https://github.com/anistark/feluda/issues/new>`_,
+or DM `@kranirudha on X <https://x.com/kranirudha>`_ / `@ani on Mastodon <https://fosstodon.org/@ani>`_.
+Even a quick "we use Feluda for X" note helps shape what gets built next.
 
 Contributors ✨
 ---------------

--- a/docs/source/integrations/github-actions.rst
+++ b/docs/source/integrations/github-actions.rst
@@ -9,6 +9,8 @@ GitHub Actions
 
    Automate license compliance checks on every push and pull request with the official Feluda GitHub Action.
 
+The action is published on the `GitHub Marketplace <https://github.com/marketplace/actions/feluda-license-scanner>`_ as **Feluda License Scanner**.
+
 ----
 
 Quick Start
@@ -194,7 +196,7 @@ Scan an external repository from your workflow:
          --ssh-passphrase "${{ secrets.SSH_PASSPHRASE }}"
 
 .. important::
-   Supply either SSH or HTTPS credentials—not both—unless your CI job truly needs the fallback.
+   Supply either SSH or HTTPS credentials (not both) unless your CI job truly needs the fallback.
 
 ----
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -37,6 +37,9 @@ Feluda likes to set the scene before he inspects a repo, so walk through this sh
 
    feluda
 
+.. tip::
+   Running in CI instead? Skip the install entirely: the :ref:`GitHub Action <github-actions>` (``uses: anistark/feluda@v1``) gates builds on license compliance in three lines.
+
 Ready for deeper filters, cache tips, and reporting workflows? Head to :ref:`cli` and :ref:`sbom` once installation is complete.
 
 ----


### PR DESCRIPTION
The GitHub Action is the main way to adopt feluda in CI, but it was buried ~600 lines into the README and absent from the docs landing page. Add a quick start near the top with the 3 line `uses: anistark/feluda@v1` snippet, marketplace and discord badges, and a "talk to us" section pointing at the Null Order discord, issues, and socials. Docs get a github action card on the landing grid, a CI tip in quickstart, a marketplace link on the action page, and the same talk to us links.