### PR TITLE
feat(scan): flag foreign license headers in own source files

### DIFF
--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -600,7 +600,18 @@ fn is_single_license_restrictive(
     config: &config::FeludaConfig,
     strict: bool,
 ) -> bool {
-    if let Some(license_data) = known_licenses.get(license_str) {
+    // Registry keys are bare ids (`GPL-2.0`), so strip an SPDX `-only`/`-or-later`/`+`
+    // modifier before the fallback lookup — suffixed ids must classify like their base
+    // license (`GPL-2.0-or-later` is exactly as copyleft as `GPL-2.0`).
+    let registry_entry = known_licenses.get(license_str).or_else(|| {
+        known_licenses.get(
+            license_str
+                .trim_end_matches('+')
+                .trim_end_matches("-only")
+                .trim_end_matches("-or-later"),
+        )
+    });
+    if let Some(license_data) = registry_entry {
         // Match against GitHub/choosealicense.com's own `conditions` vocabulary. These keys must
         // be spelled exactly as the API emits them — the correct key is `disclose-source`, NOT
         // `source-disclosure` (a non-existent key that silently matched nothing, so copyleft
@@ -1209,7 +1220,7 @@ const SOURCE_HEADER_MAX_DEPTH: usize = 3;
 const SOURCE_HEADER_MAX_FILES: usize = 50;
 
 /// File extensions whose leading comments are scanned for an SPDX header.
-const SOURCE_HEADER_EXTENSIONS: &[&str] = &[
+pub(crate) const SOURCE_HEADER_EXTENSIONS: &[&str] = &[
     "rs", "js", "jsx", "ts", "tsx", "mjs", "cjs", "py", "go", "rb", "java", "kt", "kts", "c", "h",
     "cc", "cpp", "cxx", "hpp", "hh", "cs", "php", "swift", "scala", "r",
 ];
@@ -1252,7 +1263,7 @@ pub fn detect_license_from_source_header(content: &str) -> Option<String> {
 /// Read at most [`SOURCE_HEADER_SCAN_LINES`] lines from `path` without loading the whole file,
 /// so the header scan stays cheap on large sources. Returns `None` on any read error (e.g. a
 /// non-UTF-8 file), which simply skips that file.
-fn read_header_region(path: &Path) -> Option<String> {
+pub(crate) fn read_header_region(path: &Path) -> Option<String> {
     let file = match File::open(path) {
         Ok(file) => file,
         Err(err) => {
@@ -2003,6 +2014,20 @@ mod tests {
             &registry,
             false
         ));
+    }
+
+    #[test]
+    fn test_registry_matches_only_or_later_suffixed_ids() {
+        // Registry keys are bare ids (`GPL-2.0`); SPDX `-only`/`-or-later`/`+` modifiers must
+        // classify like their base license instead of falling through to the config list
+        // (which does not cover every GPL-family version).
+        let registry = registry_with(&[("GPL-2.0", &["include-copyright", "disclose-source"])]);
+        for id in ["GPL-2.0-or-later", "GPL-2.0-only", "GPL-2.0+"] {
+            assert!(
+                is_license_restrictive(&Some(id.to_string()), &registry, false),
+                "{id} should classify like GPL-2.0"
+            );
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod manifest;
 mod parser;
 mod reporter;
 mod sbom;
+mod source_scan;
 mod spdx;
 mod table;
 mod utils;
@@ -321,7 +322,7 @@ fn analyze_dependencies(config: &CheckConfig) -> FeludaResult<(Vec<LicenseInfo>,
     }
 
     // Parse and analyze dependencies
-    let analyzed_data = parse_root(
+    let mut analyzed_data = parse_root(
         &config.path,
         config.language.as_deref(),
         config.strict,
@@ -330,6 +331,24 @@ fn analyze_dependencies(config: &CheckConfig) -> FeludaResult<(Vec<LicenseInfo>,
     .map_err(|e| FeludaError::Parser(format!("Failed to parse dependencies: {e}")))?;
 
     log_debug("Analyzed dependencies", &analyzed_data);
+
+    // Own-source header scan: flag project source files whose leading comments declare a
+    // license different from the project's (code pasted in by AI tools or copied from other
+    // projects without a manifest entry).
+    let own_source_findings = cli::with_spinner("🔎: own source license headers", |indicator| {
+        let findings = source_scan::scan_own_source_headers(
+            Path::new(&config.path),
+            project_license.as_deref(),
+            config.strict,
+        );
+        indicator.update_progress(&format!(
+            "{} finding{}",
+            findings.len(),
+            if findings.len() == 1 { "" } else { "s" }
+        ));
+        findings
+    });
+    analyzed_data.extend(own_source_findings);
 
     Ok((analyzed_data, project_license))
 }

--- a/src/source_scan.rs
+++ b/src/source_scan.rs
@@ -1,0 +1,433 @@
+//! Own-source license header scanning.
+//!
+//! Dependency analysis answers "what do my declared dependencies license as?"; this module
+//! answers "does my own code carry someone else's license?". AI coding assistants and plain
+//! copy-paste routinely introduce source files bearing an `SPDX-License-Identifier:` tag or a
+//! GNU license banner without any manifest entry, so the default scan walks the project's own
+//! source files and flags every file whose header declares a license different from the
+//! project's own.
+//!
+//! Findings are reported as [`LicenseInfo`] entries alongside dependency results — the file's
+//! relative path is the entry name and the version column carries [`OWN_SOURCE_MARKER`] — so
+//! every output mode (table, JSON, YAML, CI formats) and every filter (`--restrictive`,
+//! `--incompatible`, `--fail-on-restrictive`) applies to them unchanged.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use ignore::WalkBuilder;
+
+use crate::debug::{log, LogLevel};
+use crate::licenses::{
+    detect_license_from_source_header, fetch_licenses_from_github, get_osi_status,
+    is_license_ignored, is_license_restrictive, read_header_region, LicenseCompatibility,
+    LicenseInfo, SOURCE_HEADER_EXTENSIONS,
+};
+
+/// Marker placed in the version column of an own-source finding, distinguishing it from a
+/// dependency entry (files have no version).
+pub const OWN_SOURCE_MARKER: &str = "own source";
+
+/// Directory names never treated as own source. These hold third-party code that either the
+/// dependency analyzers already cover (`node_modules`, `target`) or that the planned vendored
+/// dependency detection will handle at directory granularity — flagging every file inside them
+/// individually would drown the report.
+const SKIP_DIRS: &[&str] = &[
+    "node_modules",
+    "target",
+    "vendor",
+    "third_party",
+    "venv",
+    ".venv",
+    "__pycache__",
+    "site-packages",
+    "bower_components",
+    "Pods",
+    "dist",
+    "build",
+];
+
+/// Flatten a comment banner into lowercase prose so phrase matching works across line breaks.
+///
+/// Banners wrap at ~70 columns with a comment prefix on every line (`// `, ` * `, `# `), so a
+/// phrase like "GNU General Public License" is routinely split mid-phrase. Stripping the
+/// leading comment punctuation from each line and joining on single spaces restores the
+/// contiguous prose.
+fn normalize_header_prose(header: &str) -> String {
+    let joined: String = header
+        .lines()
+        .map(|line| {
+            line.trim_start()
+                .trim_start_matches(['/', '*', '#', '-', ';', '!', '<'])
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    joined
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Detect a GNU license from the conventional grant banner ("This program is free software:
+/// you can redistribute it ... under the terms of the GNU General Public License ...").
+///
+/// This complements [`detect_license_from_source_header`]: older or hand-copied GPL-family
+/// files carry the prose banner rather than an SPDX tag. Matching is anchored on the grant
+/// phrase "under the terms of the GNU" so a passing prose mention of a license name does not
+/// count. Returns a canonical SPDX id with an `-only`/`-or-later` suffix derived from the
+/// banner's own wording ("either version N" / "any later version").
+fn detect_license_from_header_boilerplate(header: &str) -> Option<String> {
+    let lower = normalize_header_prose(header);
+    if !lower.contains("under the terms of the gnu") {
+        return None;
+    }
+
+    let (base, default_version) = if lower.contains("affero general public license") {
+        ("AGPL", "3.0")
+    } else if lower.contains("lesser general public license")
+        || lower.contains("library general public license")
+    {
+        ("LGPL", "2.1")
+    } else if lower.contains("general public license") {
+        ("GPL", "2.0")
+    } else {
+        return None;
+    };
+
+    // "version 2.1" must be probed before "version 2" — the latter is a substring of it.
+    let version = if lower.contains("version 2.1") {
+        "2.1"
+    } else if lower.contains("version 3") {
+        "3.0"
+    } else if lower.contains("version 2") {
+        "2.0"
+    } else {
+        default_version
+    };
+
+    let suffix = if lower.contains("any later version") {
+        "or-later"
+    } else {
+        "only"
+    };
+
+    Some(format!("{base}-{version}-{suffix}"))
+}
+
+/// Whether `path` has a source extension worth scanning for a license header.
+fn has_source_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            SOURCE_HEADER_EXTENSIONS
+                .iter()
+                .any(|known| known.eq_ignore_ascii_case(ext))
+        })
+}
+
+/// Walk the project's own source files and return every file whose leading comment region
+/// declares a license, as `(relative path, license expression)` pairs.
+///
+/// The walk honours `.gitignore`, skips hidden entries, and never descends into [`SKIP_DIRS`]
+/// (third-party code is the dependency analyzers' job). Files whose header license equals
+/// `project_license` are not findings — that is the normal shape of a project that stamps its
+/// own headers. Entries are visited in a stable order so results are deterministic.
+fn collect_header_findings(root: &Path, project_license: Option<&str>) -> Vec<(PathBuf, String)> {
+    let walker = WalkBuilder::new(root)
+        .sort_by_file_path(|a, b| a.cmp(b))
+        .filter_entry(|entry| {
+            let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
+            !(is_dir
+                && entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| SKIP_DIRS.contains(&name)))
+        })
+        .build();
+
+    let mut findings = Vec::new();
+    for entry in walker.flatten() {
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        let path = entry.path();
+        if !has_source_extension(path) {
+            continue;
+        }
+        let Some(header) = read_header_region(path) else {
+            continue;
+        };
+        let Some(found) = detect_license_from_source_header(&header)
+            .or_else(|| detect_license_from_header_boilerplate(&header))
+        else {
+            continue;
+        };
+
+        if project_license.is_some_and(|proj| proj.trim().eq_ignore_ascii_case(found.trim())) {
+            continue;
+        }
+        if is_license_ignored(Some(&found)) {
+            continue;
+        }
+
+        let rel = path.strip_prefix(root).unwrap_or(path).to_path_buf();
+        log(
+            LogLevel::Warn,
+            &format!(
+                "Own source file {} declares license {found} (project: {})",
+                rel.display(),
+                project_license.unwrap_or("unknown")
+            ),
+        );
+        findings.push((rel, found));
+    }
+    findings
+}
+
+/// Scan the project's own source files for foreign license headers and return them as
+/// [`LicenseInfo`] entries ready to be appended to the dependency report.
+///
+/// Compatibility is left [`LicenseCompatibility::Unknown`]; the caller's compatibility
+/// annotation pass fills it in exactly as it does for dependencies. The license registry is
+/// fetched only when at least one finding exists, so clean projects pay nothing.
+pub fn scan_own_source_headers(
+    root: &Path,
+    project_license: Option<&str>,
+    strict: bool,
+) -> Vec<LicenseInfo> {
+    let findings = collect_header_findings(root, project_license);
+    if findings.is_empty() {
+        return Vec::new();
+    }
+
+    let known_licenses = fetch_licenses_from_github().unwrap_or_else(|e| {
+        log(
+            LogLevel::Warn,
+            &format!("Failed to fetch license registry for own-source scan: {e}"),
+        );
+        HashMap::new()
+    });
+
+    findings
+        .into_iter()
+        .map(|(rel, found)| {
+            let osi_status = get_osi_status(&found);
+            let license = Some(found);
+            let is_restrictive = is_license_restrictive(&license, &known_licenses, strict);
+            LicenseInfo {
+                name: rel.display().to_string(),
+                version: OWN_SOURCE_MARKER.to_string(),
+                license,
+                is_restrictive,
+                compatibility: LicenseCompatibility::Unknown,
+                osi_status,
+                sub_project: None,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    const GPL2_BANNER: &str = "\
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+int main(void) { return 0; }
+";
+
+    #[test]
+    fn test_boilerplate_gpl2_or_later() {
+        assert_eq!(
+            detect_license_from_header_boilerplate(GPL2_BANNER),
+            Some("GPL-2.0-or-later".to_string())
+        );
+    }
+
+    #[test]
+    fn test_boilerplate_gpl3_or_later() {
+        let header = "\
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+";
+        assert_eq!(
+            detect_license_from_header_boilerplate(header),
+            Some("GPL-3.0-or-later".to_string())
+        );
+    }
+
+    #[test]
+    fn test_boilerplate_lgpl21() {
+        let header = "\
+/* This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version. */
+";
+        assert_eq!(
+            detect_license_from_header_boilerplate(header),
+            Some("LGPL-2.1-or-later".to_string())
+        );
+    }
+
+    #[test]
+    fn test_boilerplate_agpl3() {
+        let header = "\
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+";
+        assert_eq!(
+            detect_license_from_header_boilerplate(header),
+            Some("AGPL-3.0-or-later".to_string())
+        );
+    }
+
+    #[test]
+    fn test_boilerplate_only_variant_without_later_clause() {
+        let header = "\
+// You may redistribute this file under the terms of the GNU General
+// Public License version 2 as published by the Free Software Foundation.
+";
+        assert_eq!(
+            detect_license_from_header_boilerplate(header),
+            Some("GPL-2.0-only".to_string())
+        );
+    }
+
+    #[test]
+    fn test_boilerplate_rejects_prose_mention() {
+        // Mentions a license by name but carries no grant phrase.
+        let header =
+            "// Unlike tools covered by the GNU General Public License, this one is MIT.\n";
+        assert_eq!(detect_license_from_header_boilerplate(header), None);
+    }
+
+    #[test]
+    fn test_boilerplate_rejects_plain_code() {
+        assert_eq!(
+            detect_license_from_header_boilerplate("fn main() { println!(\"hi\"); }\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_collect_flags_foreign_spdx_header() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("pasted.py"),
+            "# SPDX-License-Identifier: GPL-3.0-only\nprint('hi')\n",
+        )
+        .unwrap();
+
+        let findings = collect_header_findings(dir.path(), Some("MIT"));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].0, PathBuf::from("pasted.py"));
+        assert_eq!(findings[0].1, "GPL-3.0-only");
+    }
+
+    #[test]
+    fn test_collect_flags_gnu_banner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("borrowed.c"), GPL2_BANNER).unwrap();
+
+        let findings = collect_header_findings(dir.path(), Some("Apache-2.0"));
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].1, "GPL-2.0-or-later");
+    }
+
+    #[test]
+    fn test_collect_skips_header_matching_project_license() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("lib.rs"),
+            "// SPDX-License-Identifier: MIT\npub fn f() {}\n",
+        )
+        .unwrap();
+
+        assert!(collect_header_findings(dir.path(), Some("MIT")).is_empty());
+        // Case differences in the header must not defeat the match.
+        assert!(collect_header_findings(dir.path(), Some("mit")).is_empty());
+    }
+
+    #[test]
+    fn test_collect_reports_header_when_project_license_unknown() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("mystery.go"),
+            "// SPDX-License-Identifier: MPL-2.0\npackage main\n",
+        )
+        .unwrap();
+
+        let findings = collect_header_findings(dir.path(), None);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].1, "MPL-2.0");
+    }
+
+    #[test]
+    fn test_collect_skips_dependency_directories() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let dep_dir = dir.path().join("node_modules").join("leftpad");
+        fs::create_dir_all(&dep_dir).unwrap();
+        fs::write(
+            dep_dir.join("index.js"),
+            "// SPDX-License-Identifier: GPL-3.0-only\nmodule.exports = {};\n",
+        )
+        .unwrap();
+        let vendor_dir = dir.path().join("vendor");
+        fs::create_dir_all(&vendor_dir).unwrap();
+        fs::write(
+            vendor_dir.join("lib.c"),
+            "/* SPDX-License-Identifier: AGPL-3.0-only */\n",
+        )
+        .unwrap();
+
+        assert!(collect_header_findings(dir.path(), Some("MIT")).is_empty());
+    }
+
+    #[test]
+    fn test_collect_ignores_non_source_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("NOTES.md"),
+            "SPDX-License-Identifier: GPL-3.0-only\n",
+        )
+        .unwrap();
+
+        assert!(collect_header_findings(dir.path(), Some("MIT")).is_empty());
+    }
+
+    #[test]
+    fn test_collect_headerless_files_are_clean() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("main.rs"), "fn main() {}\n").unwrap();
+
+        assert!(collect_header_findings(dir.path(), Some("MIT")).is_empty());
+    }
+
+    #[test]
+    fn test_collect_is_deterministic() {
+        let dir = tempfile::TempDir::new().unwrap();
+        for name in ["b.py", "a.py", "c.py"] {
+            fs::write(
+                dir.path().join(name),
+                "# SPDX-License-Identifier: GPL-3.0-only\n",
+            )
+            .unwrap();
+        }
+
+        let names: Vec<String> = collect_header_findings(dir.path(), Some("MIT"))
+            .into_iter()
+            .map(|(p, _)| p.display().to_string())
+            .collect();
+        assert_eq!(names, vec!["a.py", "b.py", "c.py"]);
+    }
+}

--- a/tests/parser_integration.rs
+++ b/tests/parser_integration.rs
@@ -1,0 +1,310 @@
+//! Integration tests across the language parsers (#120).
+//!
+//! Each test builds a self-contained fixture project in a temp directory and drives the real
+//! `feluda` binary (`CARGO_BIN_EXE_feluda`) against it, asserting on the `--json` report. The
+//! fixtures are crafted so license resolution succeeds from local sources alone — Node from
+//! `node_modules/*/package.json`, Rust from `cargo metadata` on a path dependency, Go from a
+//! module cache directory pointed at by `GOMODCACHE`/`GOPATH` — so the tests hold with or
+//! without network access.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+/// MIT license body that `detect_license_from_content` recognises; used both as fixture
+/// project licenses and as module-cache license files.
+const MIT_TEXT: &str = "MIT License\n\nCopyright (c) 2026 Fixture\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files\n";
+
+fn run_feluda(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_feluda"));
+    cmd.current_dir(dir)
+        .arg("--path")
+        .arg(dir.to_str().unwrap())
+        .args(args);
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    cmd.output().expect("failed to run feluda binary")
+}
+
+/// Run `feluda --json` on `dir` and parse the report. An empty report (no dependencies at
+/// all) produces no stdout, which parses as an empty list.
+fn scan_json(dir: &Path, extra_args: &[&str], envs: &[(&str, &str)]) -> Vec<Value> {
+    let mut args = vec!["--json"];
+    args.extend_from_slice(extra_args);
+    let output = run_feluda(dir, &args, envs);
+    assert!(
+        output.status.success(),
+        "feluda exited with {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    serde_json::from_str(trimmed)
+        .unwrap_or_else(|e| panic!("feluda emitted invalid JSON: {e}\n{stdout}"))
+}
+
+fn entry<'a>(entries: &'a [Value], name: &str) -> &'a Value {
+    entries
+        .iter()
+        .find(|e| e["name"] == name)
+        .unwrap_or_else(|| panic!("no entry named {name:?} in report: {entries:#?}"))
+}
+
+fn has_entry(entries: &[Value], name: &str) -> bool {
+    entries.iter().any(|e| e["name"] == name)
+}
+
+/// Write a Node fixture: root `package.json` plus a populated `node_modules` so licenses
+/// resolve locally instead of via the npm registry.
+fn write_node_fixture(root: &Path, deps: &[(&str, &str, &str)]) {
+    let dep_list = deps
+        .iter()
+        .map(|(name, version, _)| format!("    \"{name}\": \"{version}\""))
+        .collect::<Vec<_>>()
+        .join(",\n");
+    fs::write(
+        root.join("package.json"),
+        format!(
+            "{{\n  \"name\": \"feluda-integration-fixture\",\n  \"version\": \"1.0.0\",\n  \"license\": \"MIT\",\n  \"dependencies\": {{\n{dep_list}\n  }}\n}}\n"
+        ),
+    )
+    .unwrap();
+
+    for (name, version, license) in deps {
+        let pkg_dir = root.join("node_modules").join(name);
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(
+            pkg_dir.join("package.json"),
+            format!(
+                "{{\n  \"name\": \"{name}\",\n  \"version\": \"{version}\",\n  \"license\": \"{license}\"\n}}\n"
+            ),
+        )
+        .unwrap();
+    }
+}
+
+/// Write a Go fixture: `go.mod` requiring `module` plus a fake module cache holding its
+/// license file. Returns the env vars that point feluda's resolution at the fake cache
+/// (`GOMODCACHE` when the `go` binary answers `go env`, `GOPATH` for the fallback path).
+fn write_go_fixture(root: &Path, module: &str, version: &str) -> Vec<(String, String)> {
+    fs::write(
+        root.join("go.mod"),
+        format!("module example.com/fixture\n\ngo 1.22\n\nrequire (\n\t{module} {version}\n)\n"),
+    )
+    .unwrap();
+
+    let gopath = root.join("gopath");
+    let cache = gopath.join("pkg").join("mod");
+    let module_dir = cache.join(format!("{module}@{version}"));
+    fs::create_dir_all(&module_dir).unwrap();
+    fs::write(module_dir.join("LICENSE"), MIT_TEXT).unwrap();
+
+    vec![
+        ("GOPATH".to_string(), gopath.display().to_string()),
+        ("GOMODCACHE".to_string(), cache.display().to_string()),
+    ]
+}
+
+fn as_env(envs: &[(String, String)]) -> Vec<(&str, &str)> {
+    envs.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect()
+}
+
+#[test]
+fn node_dependencies_resolve_from_local_node_modules() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    write_node_fixture(
+        root,
+        &[
+            ("fixture-permissive", "1.3.0", "ISC"),
+            ("fixture-copyleft", "2.0.0", "GPL-3.0-only"),
+        ],
+    );
+
+    let entries = scan_json(root, &[], &[]);
+
+    let permissive = entry(&entries, "fixture-permissive");
+    assert_eq!(permissive["license"], "ISC");
+    assert_eq!(permissive["version"], "1.3.0");
+    assert_eq!(permissive["is_restrictive"], false);
+
+    let copyleft = entry(&entries, "fixture-copyleft");
+    assert_eq!(copyleft["license"], "GPL-3.0-only");
+    assert_eq!(copyleft["is_restrictive"], true);
+    assert_eq!(copyleft["compatibility"], "Incompatible");
+}
+
+#[test]
+fn fail_on_restrictive_sets_exit_code() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    write_node_fixture(root, &[("fixture-copyleft", "2.0.0", "AGPL-3.0")]);
+
+    let failing = run_feluda(root, &["--json", "--fail-on-restrictive"], &[]);
+    assert_eq!(
+        failing.status.code(),
+        Some(1),
+        "restrictive dependency must fail the scan\nstderr: {}",
+        String::from_utf8_lossy(&failing.stderr)
+    );
+
+    let passing = run_feluda(root, &["--json"], &[]);
+    assert!(
+        passing.status.success(),
+        "without --fail-on-restrictive the scan must exit 0"
+    );
+}
+
+#[test]
+fn rust_path_dependency_license_from_cargo_metadata() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let app = temp.path().join("app");
+    let lib = temp.path().join("locallib");
+    fs::create_dir_all(app.join("src")).unwrap();
+    fs::create_dir_all(lib.join("src")).unwrap();
+
+    fs::write(
+        app.join("Cargo.toml"),
+        "[package]\nname = \"fixture-app\"\nversion = \"0.1.0\"\nedition = \"2021\"\nlicense = \"MIT\"\n\n[dependencies]\nlocallib = { path = \"../locallib\" }\n",
+    )
+    .unwrap();
+    fs::write(app.join("src/main.rs"), "fn main() {}\n").unwrap();
+    fs::write(
+        lib.join("Cargo.toml"),
+        "[package]\nname = \"locallib\"\nversion = \"0.3.1\"\nedition = \"2021\"\nlicense = \"MPL-2.0\"\n",
+    )
+    .unwrap();
+    fs::write(lib.join("src/lib.rs"), "").unwrap();
+
+    let entries = scan_json(&app, &[], &[]);
+
+    let dep = entry(&entries, "locallib");
+    assert_eq!(dep["license"], "MPL-2.0");
+    assert_eq!(dep["version"], "0.3.1");
+    // MPL-2.0 is in the default restrictive config and carries `disclose-source` in the
+    // GitHub registry, so both classification paths agree.
+    assert_eq!(dep["is_restrictive"], true);
+}
+
+#[test]
+fn go_dependency_license_from_module_cache() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    let envs = write_go_fixture(root, "example.com/mylib", "v1.2.3");
+
+    let entries = scan_json(root, &[], &as_env(&envs));
+
+    let dep = entry(&entries, "example.com/mylib");
+    assert_eq!(dep["license"], "MIT");
+    assert_eq!(dep["version"], "v1.2.3");
+    assert_eq!(dep["is_restrictive"], false);
+    assert_eq!(dep["compatibility"], "Compatible");
+}
+
+#[test]
+fn python_requirements_without_dependencies_scans_clean() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    fs::write(root.join("requirements.txt"), "# no dependencies\n").unwrap();
+
+    let entries = scan_json(root, &[], &[]);
+    assert!(
+        entries.is_empty(),
+        "empty requirements.txt must produce an empty report: {entries:#?}"
+    );
+}
+
+#[test]
+fn own_source_header_findings_reported() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    write_node_fixture(root, &[]);
+
+    let src = root.join("src");
+    fs::create_dir_all(&src).unwrap();
+    // Pasted file with a foreign SPDX tag: must be flagged.
+    fs::write(
+        src.join("pasted.py"),
+        "# SPDX-License-Identifier: GPL-3.0-only\ndef pasted():\n    pass\n",
+    )
+    .unwrap();
+    // GNU grant banner without an SPDX tag: must also be flagged.
+    fs::write(
+        src.join("borrowed.c"),
+        "// This program is free software; you can redistribute it and/or modify\n// it under the terms of the GNU General Public License as published by\n// the Free Software Foundation; either version 2 of the License, or\n// (at your option) any later version.\nint main(void) { return 0; }\n",
+    )
+    .unwrap();
+    // Own header matching the project license: must not be flagged.
+    fs::write(
+        src.join("own.ts"),
+        "// SPDX-License-Identifier: MIT\nexport const ok = true;\n",
+    )
+    .unwrap();
+
+    let entries = scan_json(root, &[], &[]);
+
+    let pasted = entry(&entries, "src/pasted.py");
+    assert_eq!(pasted["version"], "own source");
+    assert_eq!(pasted["license"], "GPL-3.0-only");
+    assert_eq!(pasted["is_restrictive"], true);
+    assert_eq!(pasted["compatibility"], "Incompatible");
+
+    let borrowed = entry(&entries, "src/borrowed.c");
+    assert_eq!(borrowed["license"], "GPL-2.0-or-later");
+    assert_eq!(borrowed["is_restrictive"], true);
+
+    assert!(
+        !has_entry(&entries, "src/own.ts"),
+        "file whose header matches the project license must not be flagged: {entries:#?}"
+    );
+}
+
+#[test]
+fn multi_language_root_parses_all_ecosystems() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    write_node_fixture(root, &[("fixture-permissive", "1.3.0", "ISC")]);
+    let envs = write_go_fixture(root, "example.com/mylib", "v1.2.3");
+    fs::write(root.join("requirements.txt"), "# no dependencies\n").unwrap();
+
+    let entries = scan_json(root, &[], &as_env(&envs));
+
+    assert!(has_entry(&entries, "fixture-permissive"));
+    assert!(has_entry(&entries, "example.com/mylib"));
+}
+
+#[test]
+fn language_filter_limits_scan() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    write_node_fixture(root, &[("fixture-permissive", "1.3.0", "ISC")]);
+    let envs = write_go_fixture(root, "example.com/mylib", "v1.2.3");
+
+    let go_only = scan_json(root, &["--language", "go"], &as_env(&envs));
+    assert!(has_entry(&go_only, "example.com/mylib"));
+    assert!(
+        !has_entry(&go_only, "fixture-permissive"),
+        "--language go must exclude Node dependencies: {go_only:#?}"
+    );
+
+    let node_only = scan_json(root, &["--language", "node"], &as_env(&envs));
+    assert!(has_entry(&node_only, "fixture-permissive"));
+    assert!(
+        !has_entry(&node_only, "example.com/mylib"),
+        "--language node must exclude Go dependencies: {node_only:#?}"
+    );
+}


### PR DESCRIPTION
Dependency analysis only covers what manifests declare. AI coding assistants and plain copy-paste routinely introduce source files carrying someone else's license, an `SPDX-License-Identifier:` tag or a GNU grant banner, with no manifest entry, so nothing surfaced them.

The default scan now walks the project's own source files and flags every file whose header declares a license different from the project's. The walk honours `.gitignore`, never descends into dependency directories (`node_modules`, `vendor`, `target`, and friends), and reads only each file's leading comment region, so it stays cheap. Detection reuses the SPDX header engine from #229 and adds a grant-banner detector for pre-SPDX GPL/LGPL/AGPL headers ("under the terms of the GNU..."), with the banner prose normalized first since real banners wrap mid-phrase across comment lines. The version modifier (`-only`/`-or-later`) is derived from the banner's own wording.

Findings ride the normal report as entries named by file path with `own source` in the version column, so every output format (table, JSON, YAML, CI), every filter (`--restrictive`, `--incompatible`, `--osi`), and `--fail-on-restrictive` apply to them unchanged. The scan runs in the default check and `feluda watch`; `generate` and `sbom` output stays package-only.

Along the way this fixes restrictive classification for SPDX `-only`/`-or-later`/`+` suffixed ids: the registry lookup was exact-match, so `GPL-2.0-or-later` (exactly what the banner detector emits, and a common declared id for deps too) silently classified as non-restrictive. The lookup now strips the modifier before falling back to the base id.

Also adds integration tests across the language parsers: `tests/parser_integration.rs` drives the real binary against fixture projects and asserts on the `--json` report, covering Node, Rust, Go, and Python parsing plus the new own-source findings, `--language` filtering, and exit codes. Fixtures resolve licenses from local sources alone (Node via `node_modules/*/package.json`, Rust via a `cargo metadata` path dependency, Go via a fake module cache injected through `GOMODCACHE`/`GOPATH`), so the tests hold with or without network access.

Verified end to end: an MIT fixture project with a pasted `GPL-3.0-only` file and a GPL v2 banner file gets both flagged as restrictive and incompatible and exits 1 under `--fail-on-restrictive`, a file whose header matches the project license is not flagged, and the feluda repo itself scans clean with zero findings.

Closes #120
