### PR TITLE
feat(go): migrate license resolution to the official pkg.go.dev API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,30 +545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf 0.11.3",
-]
-
-[[package]]
-name = "cssparser"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.13.1",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.117",
+ "phf",
 ]
 
 [[package]]
@@ -711,31 +688,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
-name = "dtoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "ego-tree"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -819,7 +775,6 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "scraper",
  "semver",
  "serde",
  "serde_json",
@@ -1013,15 +968,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,16 +1103,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "html5ever"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
-dependencies = [
- "log",
- "markup5ever",
-]
 
 [[package]]
 name = "http"
@@ -1768,17 +1704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "markup5ever"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
-dependencies = [
- "log",
- "tendril",
- "web_atoms",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,12 +1786,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -2139,19 +2058,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
- "serde",
+ "phf_macros",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2160,18 +2068,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2180,18 +2078,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
+ "phf_shared",
  "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
-dependencies = [
- "fastrand",
- "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2200,21 +2088,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2225,15 +2100,6 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2279,12 +2145,6 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -2838,21 +2698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scraper"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f5297102b8b62b4454ee8561601b2d551b4913148feb4241ca9d1a04bf4526"
-dependencies = [
- "cssparser",
- "ego-tree",
- "getopts",
- "html5ever",
- "precomputed-hash",
- "selectors",
- "tendril",
-]
-
-[[package]]
 name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,25 +2724,6 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "selectors"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
-dependencies = [
- "bitflags 2.11.1",
- "cssparser",
- "derive_more",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "precomputed-hash",
- "rustc-hash",
- "servo_arc",
- "smallvec",
 ]
 
 [[package]]
@@ -3008,15 +2834,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "servo_arc"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
-dependencies = [
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -3132,30 +2949,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "string_cache"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.13.1",
- "precomputed-hash",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
-dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "strsim"
@@ -3277,16 +3070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendril"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
-dependencies = [
- "new_debug_unreachable",
- "utf-8",
-]
-
-[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,8 +3077,8 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -3337,7 +3120,7 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf 0.11.3",
+ "phf",
  "sha2",
  "signal-hook",
  "siphasher",
@@ -3770,12 +3553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3977,18 +3754,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "web_atoms"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
-dependencies = [
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "string_cache",
- "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ reqwest = { version = "0.13.2", default-features = false, features = [
 ] }
 tokio = { version = "1.52", features = ["rt"] }
 serde_json = "1.0"
-scraper = "0.26"
 owo-colors = "4.3"
 color-eyre = { version = "0.6", default-features = false }
 color-spantrace = "0.3"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -768,8 +768,8 @@ fn fetch_actual_license_content(name: &str, version: &str, project_root: &Path) 
         return Some(content);
     }
 
-    // Fetch from Go proxy for Go modules
-    if let Some(content) = fetch_license_from_go_proxy(name, version) {
+    // Fetch from the pkg.go.dev API for Go modules
+    if let Some(content) = fetch_license_from_go_pkgsite(name, version) {
         return Some(content);
     }
 
@@ -914,13 +914,42 @@ fn fetch_license_from_pypi(name: &str, version: &str) -> Option<String> {
     None
 }
 
-/// Fetch license content from Go proxy
-fn fetch_license_from_go_proxy(name: &str, version: &str) -> Option<String> {
+/// Fetch license content for Go modules from the official pkg.go.dev API
+fn fetch_license_from_go_pkgsite(name: &str, version: &str) -> Option<String> {
+    // Only module-shaped names (host.tld/path) can be Go modules
+    if !name.split('/').next()?.contains('.') || !name.contains('/') {
+        return None;
+    }
+
     log(
         LogLevel::Info,
-        &format!("Trying to fetch license from Go proxy for {name} v{version}"),
+        &format!("Trying to fetch license from pkg.go.dev for {name} v{version}"),
     );
+    rate_limit_delay();
 
+    if let Some(licenses) = crate::languages::go::fetch_pkgsite_module_licenses(name, version) {
+        let texts: Vec<&crate::languages::go::PkgsiteLicense> = licenses
+            .iter()
+            .filter(|license| !license.contents.is_empty())
+            .collect();
+
+        match texts.as_slice() {
+            [] => {} // not redistributable, or no license files; try the repository instead
+            [license] => return Some(license.contents.clone()),
+            multiple => {
+                // Several license files apply to parts of the module; label each one
+                let joined = multiple
+                    .iter()
+                    .map(|license| format!("{}:\n\n{}", license.file_path, license.contents))
+                    .collect::<Vec<_>>()
+                    .join("\n\n---\n\n");
+                return Some(joined);
+            }
+        }
+    }
+
+    // pkg.go.dev withholds license text for non-redistributable modules; the repository
+    // itself may still serve it
     if name.starts_with("github.com/") {
         let repo_url = format!(
             "https://{}",

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 use reqwest::blocking::Client;
-use scraper::{Html, Selector};
+use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -606,7 +606,7 @@ fn parse_go_module_version(module_str: &str) -> Option<(String, String)> {
     }
 }
 
-/// Fetch the license for a Go dependency, trying local sources first, then pkg.go.dev
+/// Fetch the license for a Go dependency, trying local sources first, then the pkg.go.dev API
 pub fn fetch_license_for_go_dependency(
     name: impl Into<String>,
     version: impl Into<String>,
@@ -630,7 +630,7 @@ pub fn fetch_license_for_go_dependency(
         return license;
     }
 
-    fetch_license_from_pkg_go_dev(&name)
+    fetch_license_from_pkgsite_api(&name, &version)
 }
 
 fn get_license_from_local_go_mod(package_name: &str) -> Option<String> {
@@ -727,15 +727,44 @@ fn find_license_in_any_version(root: &Path, module: &str) -> Option<String> {
     None
 }
 
-fn fetch_license_from_pkg_go_dev(name: &str) -> String {
-    let api_url = format!("https://pkg.go.dev/{name}?tab=licenses");
-    log(
-        LogLevel::Info,
-        &format!("Fetching license from Go Package Index: {api_url}"),
-    );
+// TODO: pkg.go.dev's JSON API is still in beta; move to the stable prefix (`/v1/`) once it
+// ships. Tracked upstream in https://github.com/golang/go/issues/76718.
+const PKGSITE_API_BASE: &str = "https://pkg.go.dev/v1beta";
 
+/// A single license entry from the pkg.go.dev module endpoint
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PkgsiteLicense {
+    /// Detected SPDX identifiers, or `UNKNOWN` when pkg.go.dev can't recognize the license
+    #[serde(default)]
+    pub types: Vec<String>,
+    #[serde(default)]
+    pub file_path: String,
+    /// Full license text; empty when the module is not redistributable
+    #[serde(default)]
+    pub contents: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct PkgsiteModule {
+    #[serde(default)]
+    licenses: Vec<PkgsiteLicense>,
+}
+
+/// Fetch a module's license entries from the official pkg.go.dev API.
+///
+/// Tries the exact version first and falls back to the latest version, since pkg.go.dev
+/// doesn't index every pseudo-version that appears in go.mod files.
+pub(crate) fn fetch_pkgsite_module_licenses(
+    name: &str,
+    version: &str,
+) -> Option<Vec<PkgsiteLicense>> {
     let client = match Client::builder()
-        .user_agent("feluda.anirudha.dev/1")
+        .user_agent(concat!(
+            "feluda/",
+            env!("CARGO_PKG_VERSION"),
+            " (+https://github.com/anistark/feluda)"
+        ))
         .connect_timeout(Duration::from_secs(60))
         .timeout(Duration::from_secs(10))
         .build()
@@ -743,34 +772,50 @@ fn fetch_license_from_pkg_go_dev(name: &str) -> String {
         Ok(client) => client,
         Err(err) => {
             log_error("Failed to build HTTP client", &err);
-            return "Unknown".into();
+            return None;
         }
     };
+
+    if !version.is_empty() && version != "unknown" {
+        if let Some(licenses) = fetch_pkgsite_module_version(&client, name, Some(version)) {
+            return Some(licenses);
+        }
+        log(
+            LogLevel::Warn,
+            &format!("pkg.go.dev has no entry for {name}@{version}, falling back to latest"),
+        );
+    }
+    fetch_pkgsite_module_version(&client, name, None)
+}
+
+/// Query the pkg.go.dev module endpoint for one version (`None` means latest)
+fn fetch_pkgsite_module_version(
+    client: &Client,
+    name: &str,
+    version: Option<&str>,
+) -> Option<Vec<PkgsiteLicense>> {
+    let mut api_url = format!("{PKGSITE_API_BASE}/module/{name}?licenses=true");
+    if let Some(version) = version {
+        // '+' (as in v2.0.0+incompatible) would decode as a space in a query string
+        let encoded = version.replace('+', "%2B");
+        api_url.push_str(&format!("&version={encoded}"));
+    }
+    log(
+        LogLevel::Info,
+        &format!("Fetching license from pkg.go.dev API: {api_url}"),
+    );
 
     let mut attempts = 0;
     let max_attempts = 7; // Retry max 7 times. Thala for a reason 🙌
     let wait_time = 12;
 
     while attempts < max_attempts {
-        let response = client
-            .get(&api_url)
-            .header(
-                "User-Agent",
-                "Mozilla/5.0 (compatible; Feluda-Bot/1.0; +https://github.com/anistark/feluda)",
-            )
-            .header(
-                "Accept",
-                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            )
-            .header("Referer", "https://pkg.go.dev/")
-            .send();
-
-        match response {
+        match client.get(&api_url).send() {
             Ok(response) => {
                 let status = response.status();
                 log(
                     LogLevel::Info,
-                    &format!("Go Package Index API response status: {status}"),
+                    &format!("pkg.go.dev API response status: {status}"),
                 );
 
                 if status.as_u16() == 429 {
@@ -788,87 +833,60 @@ fn fetch_license_from_pkg_go_dev(name: &str) -> String {
                 }
 
                 if status.is_success() {
-                    match response.text() {
-                        Ok(html_content) => {
-                            if let Some(license) = extract_license_from_html(&html_content) {
-                                log(
-                                    LogLevel::Info,
-                                    &format!("License found for {name}: {license}"),
-                                );
-                                return license;
-                            } else {
-                                log(
-                                    LogLevel::Warn,
-                                    &format!("No license found in HTML for {name}"),
-                                );
-                            }
-                        }
+                    match response.json::<PkgsiteModule>() {
+                        Ok(module) => return Some(module.licenses),
                         Err(err) => {
-                            log_error(&format!("Failed to extract HTML content for {name}"), &err);
+                            log_error(&format!("Failed to parse API response for {name}"), &err);
                         }
                     }
                 } else {
                     log(
-                        LogLevel::Error,
+                        LogLevel::Warn,
                         &format!("Unexpected HTTP status: {status} for {name}"),
                     );
                 }
 
-                break;
+                return None;
             }
             Err(err) => {
                 log_error(&format!("Failed to fetch metadata for {name}"), &err);
-                break;
+                return None;
             }
         }
     }
 
     log(
         LogLevel::Warn,
-        &format!("Unable to determine license for {name} after {attempts} attempts"),
+        &format!("Unable to fetch license for {name} after {attempts} attempts"),
     );
-    "Unknown".into()
+    None
 }
 
-/// Extract license information from the HTML content
-fn extract_license_from_html(html: &str) -> Option<String> {
-    log(LogLevel::Info, "Extracting license from HTML content");
+fn fetch_license_from_pkgsite_api(name: &str, version: &str) -> String {
+    fetch_pkgsite_module_licenses(name, version)
+        .and_then(|licenses| license_expression_from_pkgsite(&licenses))
+        .unwrap_or_else(|| "Unknown".into())
+}
 
-    let document = Html::parse_document(html);
-
-    // Select the <section> with class "License"
-    let section_selector = match Selector::parse("section.License") {
-        Ok(selector) => selector,
-        Err(err) => {
-            log_error("Failed to parse section selector", &err);
-            return None;
+/// Collapse pkg.go.dev license entries into a single SPDX-style expression.
+///
+/// A module can carry several license files (and a file can match several licenses); they
+/// all apply to parts of the module, so distinct identifiers are joined with `AND`.
+fn license_expression_from_pkgsite(licenses: &[PkgsiteLicense]) -> Option<String> {
+    let mut types: Vec<&str> = Vec::new();
+    for license in licenses {
+        for license_type in &license.types {
+            if license_type != "UNKNOWN" && !types.contains(&license_type.as_str()) {
+                types.push(license_type);
+            }
         }
-    };
-
-    let div_selector = match Selector::parse("h2.go-textTitle div") {
-        Ok(selector) => selector,
-        Err(err) => {
-            log_error("Failed to parse div selector", &err);
-            return None;
-        }
-    };
-
-    if let Some(section) = document.select(&section_selector).next() {
-        if let Some(div) = section.select(&div_selector).next() {
-            let license_text = div.text().collect::<Vec<_>>().join(" ").trim().to_string();
-            log(
-                LogLevel::Info,
-                &format!("License found in HTML: {license_text}"),
-            );
-            return Some(license_text);
-        } else {
-            log(LogLevel::Warn, "Found section but no license div");
-        }
-    } else {
-        log(LogLevel::Warn, "No license section found in HTML");
     }
 
-    None
+    if types.is_empty() {
+        None
+    } else {
+        Some(types.join(" AND "))
+    }
 }
 
 #[cfg(test)]
@@ -933,35 +951,90 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_license_from_html() {
-        let html_content = r#"
-            <html>
-                <body>
-                    <section class="License">
-                        <h2 class="go-textTitle">
-                            <div>MIT</div>
-                        </h2>
-                    </section>
-                </body>
-            </html>
-        "#;
+    fn test_parse_pkgsite_module_response() {
+        let json = r#"{
+            "path": "github.com/gorilla/mux",
+            "version": "v1.8.1",
+            "isLatest": true,
+            "isRedistributable": true,
+            "licenses": [
+                {
+                    "types": ["BSD-3-Clause"],
+                    "filePath": "LICENSE",
+                    "contents": "Copyright (c) 2023 The Gorilla Authors..."
+                }
+            ]
+        }"#;
 
-        let license = extract_license_from_html(html_content);
-        assert_eq!(license, Some("MIT".to_string()));
+        let module: PkgsiteModule = serde_json::from_str(json).unwrap();
+        assert_eq!(module.licenses.len(), 1);
+        assert_eq!(module.licenses[0].types, vec!["BSD-3-Clause"]);
+        assert_eq!(module.licenses[0].file_path, "LICENSE");
+        assert!(module.licenses[0].contents.starts_with("Copyright"));
+
+        let expression = license_expression_from_pkgsite(&module.licenses);
+        assert_eq!(expression, Some("BSD-3-Clause".to_string()));
     }
 
     #[test]
-    fn test_extract_license_from_html_no_license() {
-        let html_content = r#"
-            <html>
-                <body>
-                    <span class="go-Main-headerDetailItem" data-test-id="UnitHeader-licenses">
-                    </span>
-                </body>
-            </html>
-        "#;
-        let license = extract_license_from_html(html_content);
-        assert_eq!(license, None);
+    fn test_parse_pkgsite_module_response_no_licenses() {
+        // The licenses field is absent when not requested or when the module has none
+        let json = r#"{"path": "github.com/user/repo", "version": "v1.0.0"}"#;
+        let module: PkgsiteModule = serde_json::from_str(json).unwrap();
+        assert!(module.licenses.is_empty());
+        assert_eq!(license_expression_from_pkgsite(&module.licenses), None);
+    }
+
+    #[test]
+    fn test_license_expression_from_pkgsite_multiple_types() {
+        // e.g. github.com/klauspost/compress: one LICENSE file matching several licenses
+        let licenses = vec![PkgsiteLicense {
+            types: vec![
+                "Apache-2.0".to_string(),
+                "BSD-3-Clause".to_string(),
+                "MIT".to_string(),
+            ],
+            file_path: "LICENSE".to_string(),
+            contents: String::new(),
+        }];
+
+        assert_eq!(
+            license_expression_from_pkgsite(&licenses),
+            Some("Apache-2.0 AND BSD-3-Clause AND MIT".to_string())
+        );
+    }
+
+    #[test]
+    fn test_license_expression_from_pkgsite_multiple_files_deduplicated() {
+        let licenses = vec![
+            PkgsiteLicense {
+                types: vec!["MIT".to_string()],
+                file_path: "LICENSE".to_string(),
+                contents: String::new(),
+            },
+            PkgsiteLicense {
+                types: vec!["MIT".to_string(), "Apache-2.0".to_string()],
+                file_path: "third_party/LICENSE".to_string(),
+                contents: String::new(),
+            },
+        ];
+
+        assert_eq!(
+            license_expression_from_pkgsite(&licenses),
+            Some("MIT AND Apache-2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_license_expression_from_pkgsite_unknown_filtered() {
+        // Non-redistributable modules (e.g. BUSL-licensed) report UNKNOWN with no contents
+        let licenses = vec![PkgsiteLicense {
+            types: vec!["UNKNOWN".to_string()],
+            file_path: "LICENSE".to_string(),
+            contents: String::new(),
+        }];
+
+        assert_eq!(license_expression_from_pkgsite(&licenses), None);
     }
 
     #[test]


### PR DESCRIPTION
The Go network fallback scraped the pkg.go.dev licenses tab with CSS selectors, which broke whenever the HTML changed. pkg.go.dev shipped an official JSON API in May 2026 ([launch post](https://go.dev/blog/pkgsite-api), tracked in golang/go#76718), so the fallback now calls `GET /v1beta/module/{path}?licenses=true` instead ([API docs](https://pkg.go.dev/v1beta/api), [OpenAPI spec](https://pkg.go.dev/v1beta/openapi.yaml)).

Note: the issue proposed `POST /api/ModuleInfo`, but that design was superseded during the upstream proposal review; the GET endpoint above is what actually shipped (see [the issue comment](https://github.com/anistark/feluda/issues/185#issuecomment-4950637837) for the full correction).

## Changes

- `src/languages/go.rs`: replaces `fetch_license_from_pkg_go_dev` + `extract_license_from_html` with a typed client for the v1beta module endpoint. Exact version is queried first, falling back to latest since pkgsite doesn't index every pseudo-version (the old scraper always read latest, so the fallback is never worse). Multiple license files join into an SPDX `AND` expression, `UNKNOWN` maps to `Unknown`, and the 429 retry loop is unchanged (documented limit is 45 QPS per IP; our sequential, local-cache-first fetches stay far under it).
- `src/generate.rs`: THIRD_PARTY_LICENSES now sources Go license text from the same response's `contents` field. This fixes empty entries for non-GitHub module paths like `go.uber.org/zap`, which the old GitHub-repo inference could never resolve. The GitHub fallback stays for non-redistributable modules where pkgsite withholds text.
- Drops the `scraper` dependency entirely (`go.rs` was its only user), shedding the html5ever tree from `Cargo.lock`.
- A `TODO` on `PKGSITE_API_BASE` marks the `/v1beta` prefix to revisit once the stable `/v1` ships.

## Testing

- Replaced the two HTML extraction unit tests with five covering real API response parsing, absent `licenses` field, multi-type joining, cross-file dedup, and `UNKNOWN` filtering; full suite passes (483 tests, clippy clean with `-D warnings`)
- End to end: scanned a fixture from `examples/go-example` with an empty `GOMODCACHE` and no `go` binary on PATH to force every module through the API; all four resolved correctly (gin MIT, cobra Apache-2.0, testify MIT, zap MIT)
- `feluda generate` on the same fixture produced THIRD_PARTY_LICENSES.md with real license text for all four modules, including `go.uber.org/zap`

## Related

Fixes #185
