### PR TITLE
feat(tui): overhaul the --gui table layout, theme, and interactions

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -3,25 +3,42 @@ use crate::licenses::{LicenseCompatibility, LicenseInfo};
 use color_eyre::Result;
 use ratatui::{
     crossterm::event::{self, Event, KeyCode, KeyEventKind},
-    layout::{Constraint, Layout, Margin, Rect},
+    layout::{Constraint, Flex, Layout, Position, Rect},
     style::{self, Color, Modifier, Style, Stylize},
-    text::Text,
+    text::{Line, Span, Text},
     widgets::{
-        Block, BorderType, Cell, HighlightSpacing, Paragraph, Row, Scrollbar, ScrollbarOrientation,
-        ScrollbarState, Table, TableState,
+        Block, BorderType, Cell, HighlightSpacing, Padding, Paragraph, Row, Scrollbar,
+        ScrollbarOrientation, ScrollbarState, Table, TableState, Wrap,
     },
     DefaultTerminal, Frame,
 };
 use style::palette::tailwind;
 use unicode_width::UnicodeWidthStr;
 
-const INFO_TEXT: [&str; 3] = [
-    "(Esc) quit | (↑) move up | (↓) move down | (←) move left | (→) move right",
-    "(r) restrictive | (i) incompatible | (c) compatible | (a) osi-approved | (n) osi-not-approved | (u) osi-unknown | (x) clear filters | (s) sort mode",
-    "(In sort mode: ←→ select column, Enter toggle sort, Esc/q exit sort)",
+const HELP_TEXT: [&str; 14] = [
+    "Navigation",
+    "  ↑/k  move up        ↓/j  move down",
+    "  ←/h  column left    →/l  column right",
+    "  Enter  package details",
+    "",
+    "Filters (toggle)",
+    "  r  restrictive      i  incompatible     c  compatible",
+    "  a  osi-approved     n  osi-not-approved u  osi-unknown",
+    "  x  clear all filters",
+    "",
+    "Sorting",
+    "  s  enter sort mode (←→ pick column, Enter apply/toggle, Esc exit)",
+    "",
+    "  ?  toggle this help    Esc/q  quit",
 ];
 
-const ITEM_HEIGHT: usize = 4;
+const ITEM_HEIGHT: usize = 1;
+
+/// Caps applied to content-derived column widths so one long value
+/// (e.g. a 131-char license expression) cannot starve the other columns.
+const MAX_NAME_WIDTH: u16 = 35;
+const MAX_VERSION_WIDTH: u16 = 20;
+const MAX_LICENSE_WIDTH: u16 = 50;
 
 // ============================================================================
 // KEY BINDINGS CONFIGURATION
@@ -62,6 +79,12 @@ pub mod keybindings_normal {
 
     /// Sort mode
     pub const ENTER_SORT_MODE: char = 's';
+
+    /// Help overlay
+    pub const TOGGLE_HELP: char = '?';
+
+    /// Package detail popup
+    pub const SHOW_DETAILS: KeyCode = KeyCode::Enter;
 }
 
 /// Sort mode key bindings
@@ -84,7 +107,7 @@ pub mod keybindings_sort {
     pub const EXIT_SORT_MODE_CHAR: char = 'q';
 }
 
-const TABLE_COLOUR: tailwind::Palette = tailwind::RED;
+const TABLE_COLOUR: tailwind::Palette = tailwind::BLUE;
 
 #[derive(Debug, Clone, Default)]
 struct FilterState {
@@ -161,6 +184,8 @@ struct TableColors {
     header_bg: Color,
     header_fg: Color,
     row_fg: Color,
+    dim_fg: Color,
+    accent: Color,
     selected_row_style_fg: Color,
     selected_column_style_fg: Color,
     selected_cell_style_fg: Color,
@@ -173,20 +198,27 @@ struct TableColors {
     osi_approved_color: Color,
     osi_not_approved_color: Color,
     osi_unknown_color: Color,
+    restrictive_color: Color,
+    non_restrictive_color: Color,
+    glass_tint: Color,
+    glass_sheen: Color,
+    glass_border: Color,
 }
 
 impl TableColors {
     const fn new(color: &tailwind::Palette) -> Self {
         Self {
-            buffer_bg: tailwind::SLATE.c950,
-            header_bg: color.c900,
-            header_fg: tailwind::SLATE.c200,
+            buffer_bg: Color::Rgb(0, 0, 0),
+            header_bg: tailwind::SLATE.c800,
+            header_fg: tailwind::SLATE.c100,
             row_fg: tailwind::SLATE.c200,
+            dim_fg: tailwind::SLATE.c400,
+            accent: color.c400,
             selected_row_style_fg: color.c400,
             selected_column_style_fg: color.c400,
             selected_cell_style_fg: color.c600,
-            normal_row_color: tailwind::SLATE.c950,
-            alt_row_color: tailwind::SLATE.c900,
+            normal_row_color: Color::Rgb(0, 0, 0),
+            alt_row_color: tailwind::SLATE.c950,
             footer_border_color: color.c400,
             compatible_color: tailwind::GREEN.c500,
             incompatible_color: tailwind::RED.c500,
@@ -194,6 +226,11 @@ impl TableColors {
             osi_approved_color: tailwind::BLUE.c500,
             osi_not_approved_color: tailwind::ORANGE.c500,
             osi_unknown_color: tailwind::GRAY.c500,
+            restrictive_color: tailwind::RED.c500,
+            non_restrictive_color: tailwind::SLATE.c500,
+            glass_tint: tailwind::SLATE.c900,
+            glass_sheen: tailwind::SLATE.c700,
+            glass_border: tailwind::SLATE.c400,
         }
     }
 }
@@ -261,6 +298,8 @@ pub struct App {
     sort_direction: SortDirection,
     mode: AppMode,
     sort_column_selection: usize, // Index in SortColumn::all()
+    show_help: bool,
+    show_detail: bool,
 }
 
 impl App {
@@ -285,6 +324,8 @@ impl App {
             sort_direction: SortDirection::Ascending,
             mode: AppMode::Normal,
             sort_column_selection: 0,
+            show_help: false,
+            show_detail: false,
         }
     }
 
@@ -607,8 +648,34 @@ impl App {
             // Handle input events
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
+                    // Popups swallow input until dismissed
+                    if self.show_help {
+                        if matches!(
+                            key.code,
+                            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?')
+                        ) {
+                            self.show_help = false;
+                        }
+                        continue;
+                    }
+                    if self.show_detail {
+                        if matches!(key.code, KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter) {
+                            self.show_detail = false;
+                        }
+                        continue;
+                    }
+
                     match self.mode {
                         AppMode::Normal => match key.code {
+                            // Popups
+                            KeyCode::Char(c) if c == keybindings_normal::TOGGLE_HELP => {
+                                self.show_help = true;
+                            }
+                            KeyCode::Enter => {
+                                if !self.get_filtered_items().is_empty() {
+                                    self.show_detail = true;
+                                }
+                            }
                             // Quit
                             KeyCode::Esc => {
                                 log(LogLevel::Info, "Quitting TUI application");
@@ -691,30 +758,114 @@ impl App {
     }
 
     fn draw(&mut self, frame: &mut Frame) {
+        self.set_colors();
+
+        // Paint the whole frame background so gutters and bars blend in
+        frame.render_widget(
+            Block::default().style(Style::new().bg(self.colors.buffer_bg)),
+            frame.area(),
+        );
+
         // Add space for filter bar if filters are active
         let vertical = if self.filters.is_any_active() {
             Layout::vertical([
-                Constraint::Length(3),
-                Constraint::Min(5),
-                Constraint::Length(5),
+                Constraint::Length(1), // title
+                Constraint::Length(3), // filter bar
+                Constraint::Min(5),    // table
+                Constraint::Length(1), // footer
             ])
         } else {
             Layout::vertical([
+                Constraint::Length(1),
                 Constraint::Length(0),
                 Constraint::Min(5),
-                Constraint::Length(5),
+                Constraint::Length(1),
             ])
         };
         let rects = vertical.split(frame.area());
 
-        self.set_colors();
-
+        self.render_title(frame, rects[0]);
         if self.filters.is_any_active() {
-            self.render_filter_bar(frame, rects[0]);
+            self.render_filter_bar(frame, rects[1]);
         }
-        self.render_table(frame, rects[1]);
-        self.render_scrollbar(frame, rects[1]);
-        self.render_footer(frame, rects[2]);
+
+        // Reserve the rightmost column of the table area as a scrollbar gutter
+        let table_area = Rect {
+            width: rects[2].width.saturating_sub(1),
+            ..rects[2]
+        };
+        let gutter = Rect {
+            x: rects[2].x + rects[2].width.saturating_sub(1),
+            width: 1,
+            ..rects[2]
+        };
+        self.render_table(frame, table_area);
+        self.render_scrollbar(frame, gutter);
+        self.render_footer(frame, rects[3]);
+
+        if self.show_detail {
+            self.render_detail_popup(frame);
+        }
+        if self.show_help {
+            self.render_help_popup(frame);
+        }
+    }
+
+    fn render_title(&self, frame: &mut Frame, area: Rect) {
+        let restrictive_count = self.items.iter().filter(|i| i.is_restrictive).count();
+        let license_text = match &self.project_license {
+            Some(license) => license.clone(),
+            None => "Unknown".to_string(),
+        };
+
+        let mut spans = vec![
+            Span::styled(
+                " Feluda ",
+                Style::new()
+                    .fg(self.colors.header_fg)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("│ ", Style::new().fg(self.colors.dim_fg)),
+            Span::styled("Project: ", Style::new().fg(self.colors.dim_fg)),
+            Span::styled(license_text, Style::new().fg(self.colors.row_fg)),
+            Span::styled("  │  ", Style::new().fg(self.colors.dim_fg)),
+            Span::styled(
+                format!("{} packages", self.items.len()),
+                Style::new().fg(self.colors.row_fg),
+            ),
+        ];
+        if restrictive_count > 0 {
+            spans.push(Span::styled("  ·  ", Style::new().fg(self.colors.dim_fg)));
+            spans.push(Span::styled(
+                format!("{restrictive_count} restrictive"),
+                Style::new().fg(self.colors.restrictive_color),
+            ));
+        }
+        if let Some(column) = self.sort_column {
+            let direction = match self.sort_direction {
+                SortDirection::Ascending => "↑",
+                SortDirection::Descending => "↓",
+            };
+            spans.push(Span::styled("  │  ", Style::new().fg(self.colors.dim_fg)));
+            spans.push(Span::styled("Sort: ", Style::new().fg(self.colors.dim_fg)));
+            spans.push(Span::styled(
+                format!("{} {}", column.display_name(), direction),
+                Style::new().fg(self.colors.accent),
+            ));
+        }
+
+        let version = Line::from(Span::styled(
+            concat!("v", env!("CARGO_PKG_VERSION"), " "),
+            Style::new().fg(self.colors.dim_fg),
+        ))
+        .right_aligned();
+
+        let title = Block::new().title(Line::from(spans)).title(version).style(
+            Style::new()
+                .fg(self.colors.row_fg)
+                .bg(self.colors.header_bg),
+        );
+        frame.render_widget(title, area);
     }
 
     fn render_table(&mut self, frame: &mut Frame, area: Rect) {
@@ -731,11 +882,12 @@ impl App {
             .add_modifier(Modifier::REVERSED)
             .fg(self.colors.selected_cell_style_fg);
 
-        // Add Compatibility and OSI Status columns to header
-        // Add sort indicators to column headers if sorting is active
+        // Add sort indicators to column headers if sorting is active.
+        // In sort mode, the header cell under the cursor is highlighted.
         let header = SortColumn::all()
             .iter()
-            .map(|col| {
+            .enumerate()
+            .map(|(idx, col)| {
                 let mut display_name = col.display_name().to_string();
 
                 // Add sort direction indicator if this column is sorted
@@ -749,7 +901,17 @@ impl App {
                     }
                 }
 
-                Cell::from(display_name)
+                let cell = Cell::from(display_name);
+                if self.mode == AppMode::Sorting && idx == self.sort_column_selection {
+                    cell.style(
+                        Style::new()
+                            .fg(self.colors.buffer_bg)
+                            .bg(self.colors.accent)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                } else {
+                    cell
+                }
             })
             .collect::<Row>()
             .style(header_style)
@@ -769,67 +931,75 @@ impl App {
             // Style compatibility text based on its value
             let compatibility_text = match data.compatibility {
                 LicenseCompatibility::Compatible => {
-                    Text::from(format!("\n{}\n", "Compatible")).fg(self.colors.compatible_color)
+                    Text::from("Compatible").fg(self.colors.compatible_color)
                 }
                 LicenseCompatibility::Incompatible => {
-                    Text::from(format!("\n{}\n", "Incompatible")).fg(self.colors.incompatible_color)
+                    Text::from("Incompatible").fg(self.colors.incompatible_color)
                 }
                 LicenseCompatibility::Unknown => {
-                    Text::from(format!("\n{}\n", "Unknown")).fg(self.colors.unknown_color)
+                    Text::from("Unknown").fg(self.colors.unknown_color)
                 }
             };
 
             // Style OSI status text based on its value
             let osi_status_text = match data.osi_status {
                 crate::licenses::OsiStatus::Approved => {
-                    Text::from(format!("\n{}\n", "approved")).fg(self.colors.osi_approved_color)
+                    Text::from("approved").fg(self.colors.osi_approved_color)
                 }
                 crate::licenses::OsiStatus::NotApproved => {
-                    Text::from(format!("\n{}\n", "not-approved"))
-                        .fg(self.colors.osi_not_approved_color)
+                    Text::from("not-approved").fg(self.colors.osi_not_approved_color)
                 }
                 crate::licenses::OsiStatus::Unknown => {
-                    Text::from(format!("\n{}\n", "unknown")).fg(self.colors.osi_unknown_color)
+                    Text::from("unknown").fg(self.colors.osi_unknown_color)
                 }
             };
 
-            let row = Row::new([
-                Cell::from(Text::from(format!("\n{}\n", data.name))),
-                Cell::from(Text::from(format!("\n{}\n", data.version))),
-                Cell::from(Text::from(format!("\n{}\n", data.get_license()))),
-                Cell::from(Text::from(format!("\n{}\n", data.is_restrictive()))),
+            let restrictive_text = if data.is_restrictive {
+                Text::from("Yes").fg(self.colors.restrictive_color)
+            } else {
+                Text::from("No").fg(self.colors.non_restrictive_color)
+            };
+
+            Row::new([
+                Cell::from(Text::from(truncate_with_ellipsis(
+                    &data.name,
+                    MAX_NAME_WIDTH,
+                ))),
+                Cell::from(Text::from(truncate_with_ellipsis(
+                    &data.version,
+                    MAX_VERSION_WIDTH,
+                ))),
+                Cell::from(Text::from(truncate_with_ellipsis(
+                    &data.get_license(),
+                    MAX_LICENSE_WIDTH,
+                ))),
+                Cell::from(restrictive_text),
                 Cell::from(compatibility_text),
                 Cell::from(osi_status_text),
             ])
             .style(Style::new().fg(self.colors.row_fg).bg(color))
-            .height(4);
-
-            row
+            .height(ITEM_HEIGHT as u16)
         });
 
-        let bar = " █ ";
         let t = Table::new(
             rows,
             [
-                // + 1 is for padding.
-                Constraint::Length(self.longest_item_lens.0 + 1),
-                Constraint::Min(self.longest_item_lens.1 + 1),
-                Constraint::Min(self.longest_item_lens.2),
-                Constraint::Min(self.longest_item_lens.3),
-                Constraint::Min(self.longest_item_lens.4), // Compatibility column
-                Constraint::Min(self.longest_item_lens.5), // OSI Status column
+                // Name shrinks last: everything else is fixed-width, so when
+                // the terminal is narrow the Min column gives way gracefully
+                // instead of the layout dropping a column entirely.
+                Constraint::Min(self.longest_item_lens.0 + 1),
+                Constraint::Length(self.longest_item_lens.1 + 1),
+                Constraint::Length(self.longest_item_lens.2 + 1),
+                Constraint::Length(self.longest_item_lens.3),
+                Constraint::Length(self.longest_item_lens.4), // Compatibility column
+                Constraint::Length(self.longest_item_lens.5), // OSI Status column
             ],
         )
         .header(header)
         .row_highlight_style(selected_row_style)
         .column_highlight_style(selected_col_style)
         .cell_highlight_style(selected_cell_style)
-        .highlight_symbol(Text::from(vec![
-            "".into(),
-            bar.into(),
-            bar.into(),
-            "".into(),
-        ]))
+        .highlight_symbol(" █ ")
         .bg(self.colors.buffer_bg)
         .highlight_spacing(HighlightSpacing::Always);
 
@@ -891,135 +1061,399 @@ impl App {
     }
 
     fn render_scrollbar(&mut self, frame: &mut Frame, area: Rect) {
+        // Skip the header line so the track aligns with the data rows
+        let track = Rect {
+            y: area.y + 1,
+            height: area.height.saturating_sub(1),
+            ..area
+        };
         frame.render_stateful_widget(
             Scrollbar::default()
                 .orientation(ScrollbarOrientation::VerticalRight)
+                .style(Style::new().fg(self.colors.dim_fg))
+                .thumb_style(Style::new().fg(self.colors.accent))
                 .begin_symbol(None)
                 .end_symbol(None),
-            area.inner(Margin {
-                vertical: 1,
-                horizontal: 1,
-            }),
+            track,
             &mut self.scroll_state,
         );
     }
 
+    /// Build a "key label" hint pair for the footer
+    fn key_hint(&self, key: &str, label: &str) -> [Span<'static>; 2] {
+        [
+            Span::styled(
+                format!(" {key} "),
+                Style::new()
+                    .fg(self.colors.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(format!("{label}  "), Style::new().fg(self.colors.dim_fg)),
+        ]
+    }
+
     fn render_footer(&self, frame: &mut Frame, area: Rect) {
+        let hints: Vec<(&str, &str)> = if self.mode == AppMode::Sorting {
+            vec![
+                ("←→", "pick column"),
+                ("Enter", "apply / toggle direction"),
+                ("Esc", "cancel"),
+            ]
+        } else {
+            vec![
+                ("↑↓", "move"),
+                ("Enter", "details"),
+                ("s", "sort"),
+                ("r/i/c/a/n/u", "filter"),
+                ("x", "clear"),
+                ("?", "help"),
+                ("q", "quit"),
+            ]
+        };
+
+        let mut spans = Vec::with_capacity(hints.len() * 2 + 1);
         if self.mode == AppMode::Sorting {
-            // Show sort mode UI
-            let mut column_display = String::new();
-            for (idx, col) in SortColumn::all().iter().enumerate() {
-                if idx == self.sort_column_selection {
-                    column_display.push_str(&format!("[>{}< ] ", col.display_name()));
-                } else {
-                    column_display.push_str(&format!(" {}  ", col.display_name()));
+            spans.push(Span::styled(
+                " SORT ",
+                Style::new()
+                    .fg(self.colors.buffer_bg)
+                    .bg(self.colors.accent)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
+        for (key, label) in hints {
+            spans.extend(self.key_hint(key, label));
+        }
+
+        let footer = Paragraph::new(Line::from(spans)).style(
+            Style::new()
+                .fg(self.colors.row_fg)
+                .bg(self.colors.alt_row_color),
+        );
+        frame.render_widget(footer, area);
+    }
+
+    /// Centered popup rect of at most `width` x `height` within the frame
+    fn popup_area(frame: &Frame, width: u16, height: u16) -> Rect {
+        let [area] = Layout::horizontal([Constraint::Length(width)])
+            .flex(Flex::Center)
+            .areas(frame.area());
+        let [area] = Layout::vertical([Constraint::Length(height)])
+            .flex(Flex::Center)
+            .areas(area);
+        area
+    }
+
+    /// Imitate depth-of-field behind a modal: everything outside `focus`
+    /// fades toward black, so the popup reads as the only sharp layer.
+    fn render_scrim(frame: &mut Frame, focus: Rect) {
+        let area = frame.area();
+        let buf = frame.buffer_mut();
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if focus.contains(Position { x, y }) {
+                    continue;
+                }
+                if let Some(cell) = buf.cell_mut(Position { x, y }) {
+                    cell.fg = blend(cell.fg, Color::Rgb(0, 0, 0), 0.8);
+                    cell.bg = blend(cell.bg, Color::Rgb(0, 0, 0), 0.8);
                 }
             }
-
-            let current_sort = if let Some(col) = self.sort_column {
-                let dir = match self.sort_direction {
-                    SortDirection::Ascending => "↑",
-                    SortDirection::Descending => "↓",
-                };
-                format!("Current: {} {}", col.display_name(), dir)
-            } else {
-                "Current: None".to_string()
-            };
-
-            let footer_text = format!("Sort Mode\n{column_display}\n{current_sort}");
-
-            let info_footer = Paragraph::new(Text::from(footer_text))
-                .style(
-                    Style::new()
-                        .fg(self.colors.header_fg)
-                        .bg(self.colors.header_bg),
-                )
-                .centered()
-                .block(
-                    Block::bordered()
-                        .border_type(BorderType::Double)
-                        .border_style(Style::new().fg(self.colors.selected_row_style_fg)),
-                );
-            frame.render_widget(info_footer, area);
-        } else {
-            // Normal mode footer
-            // Add sort indicator if a column is being sorted
-            let sort_indicator = if let Some(column) = self.sort_column {
-                let direction = match self.sort_direction {
-                    SortDirection::Ascending => "↑",
-                    SortDirection::Descending => "↓",
-                };
-                format!(" | Sort: {} {}", column.display_name(), direction)
-            } else {
-                String::new()
-            };
-
-            // Add project license information to footer if available
-            let license_text = if let Some(ref license) = self.project_license {
-                format!("Project: {license}")
-            } else {
-                "Project: Unknown".to_string()
-            };
-
-            let footer_text = format!("{license_text} | {}{sort_indicator}", INFO_TEXT[0]);
-            let help_text = format!("\n{}\n{}", INFO_TEXT[1], INFO_TEXT[2]);
-
-            let info_footer = Paragraph::new(Text::from(format!("{footer_text}{help_text}")))
-                .style(
-                    Style::new()
-                        .fg(self.colors.row_fg)
-                        .bg(self.colors.buffer_bg),
-                )
-                .centered()
-                .block(
-                    Block::bordered()
-                        .border_type(BorderType::Double)
-                        .border_style(Style::new().fg(self.colors.footer_border_color)),
-                );
-            frame.render_widget(info_footer, area);
         }
     }
+
+    /// Frosted-glass panel: instead of clearing what's underneath, wash it
+    /// toward the tint so the table shimmers through faintly, with a lighter
+    /// sheen at the top edge like light catching glass.
+    fn render_frost(&self, frame: &mut Frame, area: Rect) {
+        let buf = frame.buffer_mut();
+        for y in area.top()..area.bottom() {
+            let depth = f32::from(y.saturating_sub(area.top())) / f32::from(area.height.max(1));
+            let tint = blend(
+                self.colors.glass_tint,
+                self.colors.glass_sheen,
+                0.45 * (1.0 - depth),
+            );
+            for x in area.left()..area.right() {
+                if let Some(cell) = buf.cell_mut(Position { x, y }) {
+                    cell.bg = blend(cell.bg, tint, 0.88);
+                    // Old glyphs stay as the faintest texture; anything more
+                    // visible competes with the card's own text
+                    cell.fg = blend(cell.fg, tint, 0.95);
+                    // A reversed or bold cell under the glass would punch
+                    // through the effect (and invert card text drawn over it)
+                    cell.modifier = Modifier::empty();
+                }
+            }
+        }
+    }
+
+    /// Scrim + frost + bordered card. The paragraph carries no background of
+    /// its own, so the frosted cells stay visible in the padding and between
+    /// spans, which is what sells the translucency.
+    fn render_glass_card(&self, frame: &mut Frame, area: Rect, title: &str, lines: Vec<Line>) {
+        Self::render_scrim(frame, area);
+        self.render_frost(frame, area);
+        frame.render_widget(
+            Paragraph::new(lines).wrap(Wrap { trim: false }).block(
+                Block::bordered()
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::new().fg(self.colors.glass_border))
+                    .padding(Padding::new(2, 2, 1, 1))
+                    .title(Span::styled(
+                        format!(" {title} "),
+                        Style::new()
+                            .fg(self.colors.header_fg)
+                            .add_modifier(Modifier::BOLD),
+                    ))
+                    .title_bottom(
+                        Line::from(Span::styled(
+                            " (Esc) close ",
+                            Style::new().fg(self.colors.dim_fg),
+                        ))
+                        .right_aligned(),
+                    ),
+            ),
+            area,
+        );
+    }
+
+    fn render_help_popup(&self, frame: &mut Frame) {
+        let width = (HELP_TEXT.iter().map(|l| l.width()).max().unwrap_or(0) as u16 + 8)
+            .min(frame.area().width.saturating_sub(4));
+        let height = (HELP_TEXT.len() as u16 + 4).min(frame.area().height.saturating_sub(2));
+        let area = Self::popup_area(frame, width, height);
+
+        let lines: Vec<Line> = HELP_TEXT
+            .iter()
+            .map(|l| Line::from(*l).fg(self.colors.row_fg))
+            .collect();
+
+        self.render_glass_card(frame, area, "Help", lines);
+    }
+
+    fn render_detail_popup(&self, frame: &mut Frame) {
+        let filtered_items = self.get_filtered_items();
+        let Some(selected) = self.state.selected() else {
+            return;
+        };
+        let Some(item) = filtered_items.get(selected).copied() else {
+            return;
+        };
+
+        let label_style = Style::new().fg(self.colors.dim_fg);
+        let value_style = Style::new().fg(self.colors.row_fg);
+
+        // Status chips: colored dot + short verdict
+        let compatibility_chip = match item.compatibility {
+            LicenseCompatibility::Compatible => (
+                self.colors.compatible_color,
+                match &self.project_license {
+                    Some(license) => format!("Compatible with {license}"),
+                    None => "Compatible".to_string(),
+                },
+            ),
+            LicenseCompatibility::Incompatible => (
+                self.colors.incompatible_color,
+                match &self.project_license {
+                    Some(license) => format!("Incompatible with {license}"),
+                    None => "Incompatible".to_string(),
+                },
+            ),
+            LicenseCompatibility::Unknown => (
+                self.colors.unknown_color,
+                "Unknown compatibility".to_string(),
+            ),
+        };
+        let osi_chip = match item.osi_status {
+            crate::licenses::OsiStatus::Approved => {
+                (self.colors.osi_approved_color, "OSI approved")
+            }
+            crate::licenses::OsiStatus::NotApproved => {
+                (self.colors.osi_not_approved_color, "Not OSI approved")
+            }
+            crate::licenses::OsiStatus::Unknown => {
+                (self.colors.osi_unknown_color, "OSI status unknown")
+            }
+        };
+        let restrictive_chip = if item.is_restrictive {
+            (self.colors.restrictive_color, "Restrictive")
+        } else {
+            (self.colors.non_restrictive_color, "Not restrictive")
+        };
+
+        let chip = |(color, text): (Color, String)| -> Vec<Span<'static>> {
+            vec![
+                Span::styled("● ", Style::new().fg(color)),
+                Span::styled(text, Style::new().fg(color)),
+                Span::raw("   "),
+            ]
+        };
+
+        let mut chips_line = Vec::new();
+        chips_line.extend(chip(compatibility_chip));
+        chips_line.extend(chip((osi_chip.0, osi_chip.1.to_string())));
+        chips_line.extend(chip((restrictive_chip.0, restrictive_chip.1.to_string())));
+
+        // How common is this exact license expression in the project?
+        let same_license_count = self
+            .items
+            .iter()
+            .filter(|other| other.get_license() == item.get_license())
+            .count()
+            .saturating_sub(1);
+        let shared_text = if same_license_count == 0 {
+            "no other package in this project".to_string()
+        } else if same_license_count == 1 {
+            "1 other package in this project".to_string()
+        } else {
+            format!("{same_license_count} other packages in this project")
+        };
+
+        let position_text = if self.filters.is_any_active() {
+            format!(
+                "{} of {} shown ({} total)",
+                selected + 1,
+                filtered_items.len(),
+                self.items.len()
+            )
+        } else {
+            format!("{} of {}", selected + 1, self.items.len())
+        };
+
+        let mut lines = vec![
+            Line::from(vec![
+                Span::styled(item.name.clone(), value_style.add_modifier(Modifier::BOLD)),
+                Span::styled(format!("  v{}", item.version), label_style),
+            ]),
+            Line::from(chips_line),
+            Line::raw(""),
+            Line::from(Span::styled("License", label_style)),
+            Line::from(Span::styled(item.get_license(), value_style)),
+            Line::raw(""),
+        ];
+        if let Some(ref sub_project) = item.sub_project {
+            lines.push(Line::from(vec![
+                Span::styled("Sub-project    ", label_style),
+                Span::styled(sub_project.clone(), value_style),
+            ]));
+        }
+        lines.push(Line::from(vec![
+            Span::styled("Same license   ", label_style),
+            Span::styled(shared_text, value_style),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("Package        ", label_style),
+            Span::styled(position_text, value_style),
+        ]));
+
+        let width = 76.min(frame.area().width.saturating_sub(4));
+        // Long license expressions wrap; leave room for the extra lines
+        let inner_width = width.saturating_sub(6).max(1);
+        let license_extra = (item.get_license().width() as u16) / inner_width;
+        let height =
+            (lines.len() as u16 + 4 + license_extra).min(frame.area().height.saturating_sub(2));
+        let area = Self::popup_area(frame, width, height);
+
+        self.render_glass_card(frame, area, "Package Details", lines);
+    }
+}
+
+/// RGB components of a color; non-RGB colors (Reset etc.) fall back to the
+/// app background so blending degrades gracefully.
+fn rgb_components(color: Color) -> (u8, u8, u8) {
+    match color {
+        Color::Rgb(r, g, b) => (r, g, b),
+        _ => (0, 0, 0), // the app background
+    }
+}
+
+/// Linear blend between two colors; `t` = 0.0 keeps `from`, 1.0 gives `to`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn blend(from: Color, to: Color, t: f32) -> Color {
+    let (fr, fg, fb) = rgb_components(from);
+    let (tr, tg, tb) = rgb_components(to);
+    let mix =
+        |f: u8, to_c: u8| -> u8 { (f32::from(f) + (f32::from(to_c) - f32::from(f)) * t) as u8 };
+    Color::Rgb(mix(fr, tr), mix(fg, tg), mix(fb, tb))
+}
+
+/// Truncate a string to `max_width` display columns, appending an ellipsis
+/// when content was cut off.
+fn truncate_with_ellipsis(s: &str, max_width: u16) -> String {
+    let max_width = max_width as usize;
+    if s.width() <= max_width {
+        return s.to_string();
+    }
+    let mut out = String::new();
+    let mut width = 0;
+    for c in s.chars() {
+        let w = c.to_string().width();
+        if width + w > max_width.saturating_sub(1) {
+            break;
+        }
+        width += w;
+        out.push(c);
+    }
+    out.push('…');
+    out
 }
 
 fn constraint_len_calculator(items: &[LicenseInfo]) -> (u16, u16, u16, u16, u16, u16) {
     log(LogLevel::Info, "Calculating column widths for table");
+
+    // Each column must fit its header plus a possible sort arrow (" ↑"),
+    // and content-driven widths are capped so one long value cannot
+    // starve the other columns out of the layout.
+    let header_len = |header: &str| header.width() + 2;
 
     let name_len = items
         .iter()
         .map(LicenseInfo::name)
         .map(UnicodeWidthStr::width)
         .max()
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .max(header_len("Name"))
+        .min(MAX_NAME_WIDTH as usize);
 
     let version_len = items
         .iter()
         .map(LicenseInfo::version)
         .map(UnicodeWidthStr::width)
         .max()
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .max(header_len("Version"))
+        .min(MAX_VERSION_WIDTH as usize);
 
     let license_len = items
         .iter()
         .map(|info| info.get_license())
         .map(|s| s.width())
         .max()
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .max(header_len("License"))
+        .min(MAX_LICENSE_WIDTH as usize);
 
-    let restricted_len = "true".width().max("false".width());
+    let restricted_len = "Yes"
+        .width()
+        .max("No".width())
+        .max(header_len("Restrictive"));
 
     // Calculate width for the Compatibility column
     let compatibility_len = ["Compatible", "Incompatible", "Unknown"]
         .iter()
         .map(|s| s.width())
         .max()
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .max(header_len("Compatibility"));
 
     // Calculate width for the OSI Status column
     let osi_status_len = ["approved", "not-approved", "unknown"]
         .iter()
         .map(|s| s.width())
         .max()
-        .unwrap_or(0);
+        .unwrap_or(0)
+        .max(header_len("OSI Status"));
 
     #[allow(clippy::cast_possible_truncation)]
     let result = (
@@ -1195,14 +1629,13 @@ mod tests {
         let (name_len, version_len, license_len, restricted_len, compatibility_len, _osi_len) =
             constraint_len_calculator(&test_data);
 
-        assert_eq!(
-            name_len,
-            "very_long_package_name_that_exceeds_normal_length".len() as u16
-        );
-        assert_eq!(version_len, "1.0.0-beta.1+build.123".len() as u16);
+        // Content longer than the caps is clamped
+        assert_eq!(name_len, MAX_NAME_WIDTH);
+        assert_eq!(version_len, MAX_VERSION_WIDTH);
         assert_eq!(license_len, "Apache-2.0".len() as u16);
-        assert_eq!(restricted_len, "false".len() as u16);
-        assert_eq!(compatibility_len, "Incompatible".len() as u16);
+        // Fixed columns are sized to their headers plus sort-arrow room
+        assert_eq!(restricted_len, "Restrictive".len() as u16 + 2);
+        assert_eq!(compatibility_len, "Compatibility".len() as u16 + 2);
     }
 
     #[test]
@@ -1211,11 +1644,12 @@ mod tests {
         let (name_len, version_len, license_len, restricted_len, compatibility_len, _osi_len) =
             constraint_len_calculator(&test_data);
 
-        assert_eq!(name_len, 0);
-        assert_eq!(version_len, 0);
-        assert_eq!(license_len, 0);
-        assert_eq!(restricted_len, "false".len() as u16);
-        assert_eq!(compatibility_len, "Incompatible".len() as u16);
+        // With no items, columns still fit their headers plus sort-arrow room
+        assert_eq!(name_len, "Name".len() as u16 + 2);
+        assert_eq!(version_len, "Version".len() as u16 + 2);
+        assert_eq!(license_len, "License".len() as u16 + 2);
+        assert_eq!(restricted_len, "Restrictive".len() as u16 + 2);
+        assert_eq!(compatibility_len, "Compatibility".len() as u16 + 2);
     }
 
     #[test]
@@ -1269,7 +1703,7 @@ mod tests {
 
         let (_, _, _, _, compatibility_len, _) = constraint_len_calculator(&test_data);
 
-        assert_eq!(compatibility_len, "Incompatible".len() as u16);
+        assert_eq!(compatibility_len, "Compatibility".len() as u16 + 2);
     }
 
     #[test]
@@ -1297,27 +1731,37 @@ mod tests {
 
         let (_, _, _, restricted_len, _, _) = constraint_len_calculator(&test_data);
 
-        assert_eq!(restricted_len, "false".len() as u16);
+        assert_eq!(restricted_len, "Restrictive".len() as u16 + 2);
     }
 
     #[test]
     fn test_item_height_constant() {
-        assert_eq!(ITEM_HEIGHT, 4);
+        assert_eq!(ITEM_HEIGHT, 1);
     }
 
     #[test]
-    fn test_info_text_constant() {
-        assert_eq!(INFO_TEXT.len(), 3);
-        assert!(INFO_TEXT[0].contains("Esc"));
-        assert!(INFO_TEXT[0].contains("quit"));
-        assert!(INFO_TEXT[0].contains("move up"));
-        assert!(INFO_TEXT[0].contains("move down"));
-        assert!(INFO_TEXT[1].contains("restrictive"));
-        assert!(INFO_TEXT[1].contains("incompatible"));
-        assert!(INFO_TEXT[1].contains("compatible"));
-        assert!(INFO_TEXT[1].contains("sort mode"));
-        assert!(INFO_TEXT[2].contains("sort mode"));
-        assert!(INFO_TEXT[2].contains("Enter"));
+    fn test_help_text_constant() {
+        let help = HELP_TEXT.join("\n");
+        assert!(help.contains("quit"));
+        assert!(help.contains("move up"));
+        assert!(help.contains("move down"));
+        assert!(help.contains("restrictive"));
+        assert!(help.contains("incompatible"));
+        assert!(help.contains("compatible"));
+        assert!(help.contains("sort mode"));
+        assert!(help.contains("Enter"));
+        assert!(help.contains("details"));
+    }
+
+    #[test]
+    fn test_truncate_with_ellipsis() {
+        assert_eq!(truncate_with_ellipsis("short", 10), "short");
+        assert_eq!(truncate_with_ellipsis("exactly-10", 10), "exactly-10");
+        assert_eq!(
+            truncate_with_ellipsis("this is far too long", 10),
+            "this is f…"
+        );
+        assert_eq!(truncate_with_ellipsis("", 10), "");
     }
 
     #[test]
@@ -1348,8 +1792,8 @@ mod tests {
         assert_eq!(app.longest_item_lens.0, "much_longer_name".len() as u16);
         assert_eq!(app.longest_item_lens.1, "1.0.0-beta".len() as u16);
         assert_eq!(app.longest_item_lens.2, "Apache-2.0".len() as u16);
-        assert_eq!(app.longest_item_lens.3, "false".len() as u16);
-        assert_eq!(app.longest_item_lens.4, "Incompatible".len() as u16);
+        assert_eq!(app.longest_item_lens.3, "Restrictive".len() as u16 + 2);
+        assert_eq!(app.longest_item_lens.4, "Compatibility".len() as u16 + 2);
     }
 
     #[test]


### PR DESCRIPTION
The Name column vanished entirely on real projects: one long license expression (aws-lc-sys is 131 chars) drove a Min constraint past the terminal width and the layout solver collapsed the Length-constrained Name column to zero. Column widths are now capped, include their header text, and Name shrinks last, so every column survives down to 80 cols and long values get a proper `…` ellipsis.

Looks like this now:

<img width="1916" height="1044" alt="feluda-tui-after" src="https://github.com/user-attachments/assets/242efce6-9853-48e0-856d-a335da4370d6" />


The rest is a visual and interaction rework on top of that fix:

- rows are 1 line instead of 4, so a 45-line terminal shows 42 packages instead of 10
- dark glassmorphic theme: pure black background with subtle zebra rows, slate chrome with a blue accent; red only means something now (restrictive, incompatible), and the Restrictive column reads Yes/No in color instead of true/false
- title bar with project license, package count, restrictive count, active sort, and the running version; the scrollbar gets its own gutter instead of drawing over the last column
- footer is one line of key hints, with the full reference behind a `?` help popup
- sort mode highlights the actual column header under the cursor instead of the old `[>Name<]` footer widget
- Enter opens a package details card: colored status chips (compatibility against the project license, OSI verdict, restrictiveness), the full untruncated license expression, how many other packages share the same license, and the package position in the current view
- popups imitate glassmorphism instead of clearing to a solid block: an 80% scrim fades everything behind the modal toward black, and the card frosts the cells underneath toward a slate tint with a lighter sheen at the top edge, so the table shimmers through like translucent glass without competing with the card's text

<img width="1914" height="1045" alt="feluda-tui-card" src="https://github.com/user-attachments/assets/ef394fac-4cb7-4f62-a3ce-ce8ab032a737" />
