### PR TITLE
fix(node): strip YAML quotes from scoped dep names in pnpm-lock.yaml

### DIFF
--- a/src/languages/node.rs
+++ b/src/languages/node.rs
@@ -2420,11 +2420,15 @@ fn parse_pnpm_lockfile_enhanced(project_root: &Path) -> Result<HashMap<String, S
             }
             Some("dependencies") | Some("devDependencies") | Some("optionalDependencies") => {
                 if let Some(colon_pos) = trimmed.find(':') {
-                    let name = trimmed[..colon_pos].trim();
+                    let name = trimmed[..colon_pos]
+                        .trim()
+                        .trim_matches('\'')
+                        .trim_matches('"');
                     let version_spec = trimmed[colon_pos + 1..].trim();
 
                     if !name.is_empty() && !version_spec.is_empty() {
-                        let clean_version = clean_version_string(version_spec);
+                        let clean_version =
+                            clean_version_string(version_spec.trim_matches('\'').trim_matches('"'));
                         deps.insert(name.to_string(), clean_version);
                     }
                 }
@@ -2763,5 +2767,85 @@ mod tests {
             temp.path().join("package.json").to_str().unwrap(),
         );
         assert!(attribution.is_empty());
+    }
+
+    #[test]
+    fn test_parse_pnpm_lockfile_enhanced_strips_quotes_from_scoped_deps() {
+        let temp = TempDir::new().unwrap();
+        let lockfile = "\
+dependencies:
+  '@babel/code-frame': 7.26.2
+  lodash: 4.17.21
+";
+        fs::write(temp.path().join("pnpm-lock.yaml"), lockfile).unwrap();
+
+        let deps = parse_pnpm_lockfile_enhanced(temp.path()).unwrap();
+        assert_eq!(deps.get("@babel/code-frame"), Some(&"7.26.2".to_string()));
+        assert_eq!(deps.get("lodash"), Some(&"4.17.21".to_string()));
+        // No entry should have a leading quote:
+        assert!(deps.keys().all(|k| !k.starts_with('\'')));
+    }
+
+    #[test]
+    fn test_pnpm_lockfile_quoted_and_unquoted_names_collapse() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        // The SAME package (@babel/core) is discoverable through two paths that
+        // produce different names pre-fix:
+        //   - the `packages:` section + .pnpm virtual store + node_modules all
+        //     yield the unquoted name `@babel/core`;
+        //   - the `dependencies:` section of pnpm-lock.yaml is parsed by
+        //     parse_pnpm_lockfile_enhanced, which pre-fix kept the YAML-mandated
+        //     quotes around the `@`-prefixed key, yielding `'@babel/core'`.
+        // Without the quote-stripping fix those are two distinct HashMap keys —
+        // a phantom duplicate row, exactly the symptom reported in issue #98.
+        // With the fix both names normalise to `@babel/core` and collapse to
+        // one entry.
+        fs::write(
+            root.join("pnpm-lock.yaml"),
+            "packages:\n  /@babel/core@7.26.9:\n    resolution: {integrity: sha1-deadbeef}\ndependencies:\n  '@babel/core': 7.26.9\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("package.json"),
+            r#"{"name":"x","version":"1.0.0","dependencies":{"@babel/core":"^7.26.9"}}"#,
+        )
+        .unwrap();
+        // virtual store mirror
+        let vs = root.join("node_modules/.pnpm/@babel+core@7.26.9/node_modules/@babel/core");
+        fs::create_dir_all(&vs).unwrap();
+        fs::write(
+            vs.join("package.json"),
+            r#"{"name":"@babel/core","version":"7.26.9","license":"MIT"}"#,
+        )
+        .unwrap();
+        // top-level symlink target
+        let top = root.join("node_modules/@babel/core");
+        fs::create_dir_all(&top).unwrap();
+        fs::write(
+            top.join("package.json"),
+            r#"{"name":"@babel/core","version":"7.26.9","license":"MIT"}"#,
+        )
+        .unwrap();
+
+        let deps = analyze_pnpm_project_comprehensive(root, "package.json");
+        // Exactly one entry for @babel/core — not a quoted phantom twin. The
+        // filter matches both `@babel/core` and `'@babel/core'` so it counts
+        // the duplicate the quote bug would introduce.
+        let babel_entries: Vec<_> = deps
+            .iter()
+            .filter(|(k, _)| k.trim_matches('\'') == "@babel/core")
+            .collect();
+        assert_eq!(
+            babel_entries.len(),
+            1,
+            "expected a single @babel/core entry, got {babel_entries:?}\nfull deps: {deps:?}"
+        );
+        assert_eq!(deps.get("@babel/core").map(String::as_str), Some("7.26.9"));
+        // No key should retain a leading quote (the quote-bug signature).
+        assert!(
+            deps.keys().all(|k| !k.starts_with('\'')),
+            "quoted key leaked into deps: {deps:?}"
+        );
     }
 }

--- a/tests/parser_integration.rs
+++ b/tests/parser_integration.rs
@@ -308,3 +308,63 @@ fn language_filter_limits_scan() {
         "--language node must exclude Go dependencies: {node_only:#?}"
     );
 }
+
+#[test]
+fn pnpm_project_does_not_emit_duplicate_license_rows() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    // The SAME package (@babel/core) is declared in both sections of
+    // pnpm-lock.yaml. Pre-fix, parse_pnpm_lockfile_enhanced kept the
+    // YAML-mandated quotes around the `@`-prefixed key in `dependencies:`,
+    // yielding `'@babel/core'` — a distinct name from the unquoted
+    // `@babel/core` produced by the `packages:` section / virtual store. The
+    // result was a phantom duplicate license row, exactly issue #98.
+    fs::write(
+        root.join("package.json"),
+        r#"{"name":"fixture","version":"1.0.0","license":"MIT",
+           "dependencies":{"@babel/core":"^7.26.9"}}"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("pnpm-lock.yaml"),
+        "packages:\n  /@babel/core@7.26.9:\n    resolution: {integrity: sha1-deadbeef}\ndependencies:\n  '@babel/core': 7.26.9\n",
+    )
+    .unwrap();
+
+    // Virtual store entry with its own LICENSE so resolution succeeds locally
+    // and the surviving row is MIT rather than a spurious "Unknown".
+    let vs = root.join("node_modules/.pnpm/@babel+core@7.26.9/node_modules/@babel/core");
+    fs::create_dir_all(&vs).unwrap();
+    fs::write(
+        vs.join("package.json"),
+        r#"{"name":"@babel/core","version":"7.26.9","license":"MIT"}"#,
+    )
+    .unwrap();
+    fs::write(vs.join("LICENSE"), MIT_TEXT).unwrap();
+
+    let entries = scan_json(root, &[], &[]);
+
+    // Exactly one row for @babel/core — not two. The filter matches both
+    // `@babel/core` and `'@babel/core'` so it counts the phantom twin the
+    // quote bug would introduce.
+    let core_rows: Vec<_> = entries
+        .iter()
+        .filter(|e| e["name"].as_str().unwrap_or("").trim_matches('\'') == "@babel/core")
+        .collect();
+    assert_eq!(
+        core_rows.len(),
+        1,
+        "expected exactly one @babel/core row, got {core_rows:?}\nfull report: {entries:#?}"
+    );
+    assert_eq!(core_rows[0]["license"], "MIT");
+
+    // And no row should ever have a name beginning with a single quote
+    // (the signature of the parse_pnpm_lockfile_enhanced quote bug).
+    assert!(
+        entries
+            .iter()
+            .all(|e| !e["name"].as_str().unwrap_or("").starts_with('\'')),
+        "found a quoted-name row (parse_pnpm_lockfile_enhanced quote bug): {entries:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #98.

When `parse_pnpm_lockfile_enhanced` parsed the `dependencies:` / `devDependencies:` / `optionalDependencies:` sections of `pnpm-lock.yaml`, it kept the YAML-mandated single quotes around `@`-prefixed (scoped) package names. For example, the lockfile line:

```yaml
dependencies:
  '@babel/core': 7.26.9
```

was parsed into a HashMap key `'@babel/core'` (with literal quotes), while the same package discovered through the `packages:` section, the `.pnpm` virtual store, or `node_modules` symlink resolution produced the unquoted name `@babel/core`. Because these are two distinct HashMap keys, the same dependency ended up as **two separate `LicenseInfo` rows** in the final report — exactly the "more licenses than listed in pnpm tree" symptom reported in #98.

The quoted name also broke downstream license resolution: `get_license_for_package` builds paths like `node_modules/'@babel/core'/package.json` (with a literal `'` in the path), which never exist, so the affected rows fell back to `"Unknown (failed to retrieve)"`.

## The fix

Strip surrounding single and double quotes from both the dependency name and version string in the `dependencies`/`devDependencies`/`optionalDependencies` arm of `parse_pnpm_lockfile_enhanced`. Once the names are unquoted, they collide correctly with the unquoted forms produced by the other detection methods, collapsing the phantom duplicate rows.

This is a 6-line change in `src/languages/node.rs`. The `packages:` arm is untouched (it routes through `parse_pnpm_package_entry`, which already receives unquoted input).

## Reproduction

A minimal pnpm project with one scoped dependency (`@babel/core`) declared in both the `packages:` section and the `dependencies:` section of `pnpm-lock.yaml`:

**Before this fix** — `feluda --json` emits two rows for the same package:
```json
[
  { "name": "@babel/core",        "version": "7.26.9", "license": "MIT" },
  { "name": "'@babel/core'",      "version": "7.26.9", "license": "Unknown (failed to retrieve)" }
]
```

**After this fix** — one row:
```json
[
  { "name": "@babel/core", "version": "7.26.9", "license": "MIT" }
]
```

## Tests

Three regression tests are added, each verified to fail without the fix and pass with it:

1. **`test_parse_pnpm_lockfile_enhanced_strips_quotes_from_scoped_deps`** (unit) — parses a lockfile with `'@babel/code-frame': 7.26.2` and asserts the key is stored as `@babel/code-frame` (no leading quote).
2. **`test_pnpm_lockfile_quoted_and_unquoted_names_collapse`** (unit) — builds a fixture where `@babel/core` is discoverable through both the `dependencies:` section (quoted pre-fix) and the `.pnpm` virtual store (unquoted), and asserts the resulting HashMap has exactly one entry.
3. **`pnpm_project_does_not_emit_duplicate_license_rows`** (integration, in `tests/parser_integration.rs`) — runs the real `feluda --json` binary against a fixture and asserts exactly one `@babel/core` row with a valid `MIT` license, and that no row name starts with `'`.

## Verification

```
cargo fmt --all -- --check          # clean
cargo clippy --all-targets --all-features -- -D warnings   # 0 warnings
cargo test --bin feluda             # all tests pass (except a pre-existing network-dependent test in src/debug.rs unrelated to this change)
cargo test --test parser_integration # 9/9 pass
```

## Scope

- Only `src/languages/node.rs` and `tests/parser_integration.rs` are modified.
- No new dependencies, no CLI/config surface changes, no changes to other language modules.
- Diff: +148 / -2 lines (the fix itself is 6 lines; the rest is tests and comments).

## Notes

- A separate, deeper concern (that `all_deps: HashMap<String, String>` is keyed by name only, so two co-installed versions of the same package collapse to one entry) was identified during analysis but is **out of scope** for this PR. That change would require modifying the accumulator data structure and its downstream consumers, which is better suited to a dedicated follow-up. This PR focuses on the specific duplicate-rows symptom reported in #98.