### PR TITLE
feat(licenses): custom license definitions and unlicensed vendored code

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,29 @@ ignore = [
 ]
 ```
 
+### Custom Licenses
+
+Feluda's built-in rules recognise the common license texts, but some projects ship one those rules cannot place: a bespoke internal license, a rewording of a standard one, or a standard text wrapped in a custom preamble. Those show up in reports as Unknown. A custom definition names the phrases that identify such a text and the id to report when they all appear.
+
+```toml
+[[licenses.custom]]
+id = "LicenseRef-acme-internal"
+match_all = ["ACME CONFIDENTIAL", "Internal Use Only"]
+restrictive = true
+```
+
+| Field | Meaning |
+| --- | --- |
+| `id` | The identifier to report. Use the real SPDX id when the text is a known license Feluda misses, or a `LicenseRef-` prefixed id (the SPDX convention for licenses outside the register) for something bespoke. |
+| `match_all` | Phrases that must **all** appear in the license text. Matching is case-sensitive on plain substrings, so lift phrases straight out of the file. At least one is required. |
+| `restrictive` | Optional. Whether a match counts as restrictive. Leave it out to classify `id` through the license registry and the `restrictive` list. |
+
+Custom definitions are tried before the built-in rules, so they also correct a text Feluda places wrongly. Repeat the same `id` across several entries to accept more than one wording of one license, and list the most specific rules first, because the first match wins.
+
+`restrictive` works both ways. Setting it to `false` stops flagging a license your legal team has already cleared, which is narrower than adding that license to `ignore`, since the dependency still appears in reports, NOTICE files, and SBOMs.
+
+**Note**: Definitions match on license *text*, so they apply wherever Feluda reads a license file: dependency license fallbacks, vendored directories, and stray `LICENSE` files. They do not rewrite an id a package manifest declares outright.
+
 ### Ignoring Dependencies
 
 The `[dependencies]` section allows you to exclude entire dependencies from license scanning, regardless of their license. This is useful when:

--- a/docs/source/cli/scan.rst
+++ b/docs/source/cli/scan.rst
@@ -175,12 +175,21 @@ Findings are named by their path and marked in the version column:
 
    │ src/pasted.py       │ own source │ GPL-3.0-only │ true  │ Incompatible │
    │ vendor/gpl-lib      │ vendored   │ GPL-3.0      │ true  │ Incompatible │
-   │ third_party/mystery │ vendored   │ No License   │ false │ Unknown      │
+   │ third_party/mystery │ vendored   │ No License   │ true  │ Unknown      │
    │ scripts/snippet     │ unmanaged  │ GPL-2.0      │ true  │ Incompatible │
 
-A vendored directory carrying no license at all is still reported — code
-copied in with no attribution is exactly what these scans exist to surface.
-Use ``--strict`` to treat those unresolved licenses as restrictive.
+A vendored directory carrying no license at all is still reported, because
+code copied in with no attribution is exactly what these scans exist to
+surface. It is also reported as **restrictive**, without needing ``--strict``.
+
+That is deliberately stricter than how Feluda treats a dependency whose
+license it could not resolve. An unresolved dependency license is a gap in
+Feluda's knowledge, so it stays non-restrictive unless you ask for
+``--strict``. A directory of code sitting in your tree with no license file
+and no SPDX header is a different kind of claim: it is an observation about
+the code itself, and no license means no grant of permission. So
+``--fail-on-restrictive`` stops a build on unattributed vendored code by
+default.
 
 Feluda suppresses the obvious duplicates: a vendored directory matching a
 dependency the manifests already declare (a ``go mod vendor`` tree, say) is

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -96,6 +96,67 @@ Feluda removes matching dependencies from every report, keeping NOTICE files and
 
 ----
 
+Teach Feluda a license it does not know
+---------------------------------------
+
+Feluda's built-in rules recognise the common license texts, but some projects
+ship one those rules cannot place: a bespoke internal license, a rewording of a
+standard one, or a standard text wrapped in a custom preamble. Those land in the
+report as Unknown. A custom definition names the phrases that identify such a
+text and the id to report when they all appear.
+
+Use this snippet when a license text keeps resolving to Unknown.
+
+.. code-block:: toml
+
+   [[licenses.custom]]
+   id = "LicenseRef-acme-internal"
+   match_all = ["ACME CONFIDENTIAL", "Internal Use Only"]
+   restrictive = true
+
+Feluda now reports ``LicenseRef-acme-internal`` for any license file containing
+both phrases, and treats it as restrictive, so ``--fail-on-restrictive`` and
+every filter apply to it like any other license.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Field
+     - Meaning
+   * - ``id``
+     - The identifier to report. Use the real SPDX id when the text is a known
+       license Feluda misses, or a ``LicenseRef-`` prefixed id (the SPDX
+       convention for licenses outside the register) for something bespoke.
+   * - ``match_all``
+     - Phrases that must **all** appear in the license text. Matching is
+       case-sensitive on plain substrings, so lift phrases straight out of the
+       file. At least one is required.
+   * - ``restrictive``
+     - Optional. Whether a match counts as restrictive. Leave it out to
+       classify ``id`` through the license registry and the ``restrictive``
+       list above.
+
+Custom definitions are tried before the built-in rules, so they also correct a
+text Feluda places wrongly. Repeat the same ``id`` across several entries to
+accept more than one wording of one license, and list the most specific rules
+first, because the first match wins.
+
+.. tip::
+   ``restrictive`` works in both directions. Set it to ``false`` to stop
+   flagging a license your legal team has already cleared, which is narrower
+   than adding the license to ``ignore``, since the dependency still appears in
+   reports, NOTICE files, and SBOMs.
+
+.. note::
+   Definitions match on license **text**, so they apply wherever Feluda reads a
+   license file: dependency license fallbacks, vendored directories, and stray
+   ``LICENSE`` files. They do not rewrite an id a package manifest declares
+   outright, and they cannot override a filename that implies an id on its own,
+   such as ``OFL.txt``.
+
+----
+
 Manage compatibility rules
 --------------------------
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,13 @@
 //!     "Apache-2.0",   # Apache License 2.0
 //! ]
 //!
+//! # Teach Feluda a license text its built-in rules cannot place. Every marker in
+//! # `match_all` must appear in the license file for the rule to match.
+//! [[licenses.custom]]
+//! id = "LicenseRef-acme-internal"
+//! match_all = ["ACME CONFIDENTIAL", "Internal Use Only"]
+//! restrictive = true
+//!
 //! [[dependencies.ignore]]
 //! name = "github.com/opcotech/elemo-pre-mailer"
 //! version = "v1.0.0"
@@ -93,6 +100,8 @@ pub struct LicenseConfig {
     pub restrictive: Vec<String>,
     #[serde(default)]
     pub ignore: Vec<String>,
+    #[serde(default)]
+    pub custom: Vec<CustomLicense>,
 }
 
 impl Default for LicenseConfig {
@@ -100,8 +109,43 @@ impl Default for LicenseConfig {
         Self {
             restrictive: default_restrictive_licenses(),
             ignore: Vec::new(),
+            custom: Vec::new(),
         }
     }
+}
+
+/// A user-defined license definition.
+///
+/// Feluda's built-in content rules cover the common licenses, but some projects publish a license
+/// text those rules cannot place: a bespoke internal license, a dual-license preamble wrapped
+/// around a standard text, or a rewording of a known license. A custom definition names the
+/// markers that identify such a text and the identifier to report when they are all present, so
+/// the license resolves instead of landing in the report as Unknown.
+///
+/// ```toml
+/// [[licenses.custom]]
+/// id = "LicenseRef-acme-internal"
+/// match_all = ["ACME CONFIDENTIAL", "Internal Use Only"]
+/// restrictive = true
+/// ```
+///
+/// Repeat the same `id` across several entries to accept more than one wording of one license;
+/// the first entry whose markers all match wins, so list the most specific rules first.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CustomLicense {
+    /// The identifier reported when this rule matches. Use the real SPDX id when the text is a
+    /// known license Feluda's built-in rules miss, or a `LicenseRef-` prefixed id (the SPDX
+    /// convention for licenses outside the register) for something bespoke.
+    pub id: String,
+    /// Markers that must **all** appear in the license text for the rule to match. Matching is
+    /// case-sensitive and on plain substrings, so lift distinctive phrases straight out of the
+    /// license text.
+    #[serde(default)]
+    pub match_all: Vec<String>,
+    /// Whether a match counts as restrictive. Leave it out to classify `id` the usual way,
+    /// through the license registry and the `restrictive` list above.
+    #[serde(default)]
+    pub restrictive: Option<bool>,
 }
 
 impl LicenseConfig {
@@ -201,8 +245,59 @@ impl LicenseConfig {
             );
         }
 
+        self.validate_custom()?;
+
         log_debug("License configuration validation passed", &self.restrictive);
         log_debug("Ignore licenses configuration", &self.ignore);
+        Ok(())
+    }
+
+    /// Validates the user-defined license definitions.
+    ///
+    /// A rule with no markers would match every license text, so it is rejected outright rather
+    /// than silently relabelling the whole report.
+    fn validate_custom(&self) -> FeludaResult<()> {
+        for rule in &self.custom {
+            if rule.id.trim().is_empty() {
+                return Err(FeludaError::Config(
+                    "Custom license definition is missing an 'id'".to_string(),
+                ));
+            }
+
+            if rule.match_all.is_empty() {
+                return Err(FeludaError::Config(format!(
+                    "Custom license '{}' has no 'match_all' markers, which would match every \
+                     license text",
+                    rule.id
+                )));
+            }
+
+            if rule.match_all.iter().any(|marker| marker.trim().is_empty()) {
+                return Err(FeludaError::Config(format!(
+                    "Custom license '{}' has an empty marker in 'match_all'",
+                    rule.id
+                )));
+            }
+        }
+
+        // Two rules sharing an id are how one license with several wordings is expressed, so only
+        // a fully duplicated rule is worth mentioning.
+        let mut seen = std::collections::HashSet::new();
+        for rule in &self.custom {
+            if !seen.insert((&rule.id, &rule.match_all)) {
+                log(
+                    LogLevel::Warn,
+                    &format!(
+                        "Duplicate custom license definition for '{}' will never be reached",
+                        rule.id
+                    ),
+                );
+            }
+        }
+
+        if !self.custom.is_empty() {
+            log_debug("Custom license definitions", &self.custom.len());
+        }
         Ok(())
     }
 
@@ -716,6 +811,7 @@ restrictive = ["TOML-LICENSE-1", "TOML-LICENSE-2"]"#,
             licenses: LicenseConfig {
                 restrictive: vec!["TEST-1.0".to_string(), "TEST-2.0".to_string()],
                 ignore: Vec::new(),
+                custom: Vec::new(),
             },
             dependencies: DependencyConfig {
                 max_depth: 5,
@@ -751,6 +847,7 @@ restrictive = ["TOML-LICENSE-1", "TOML-LICENSE-2"]"#,
         let config = LicenseConfig {
             restrictive: vec!["MIT".to_string(), "Apache-2.0".to_string()],
             ignore: Vec::new(),
+            custom: Vec::new(),
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -848,6 +945,7 @@ restrictive = [
         let config = LicenseConfig {
             restrictive: vec![],
             ignore: Vec::new(),
+            custom: Vec::new(),
         };
         // Empty list should pass validation but generate a warning
         assert!(config.validate().is_ok());
@@ -858,6 +956,7 @@ restrictive = [
         let config = LicenseConfig {
             restrictive: vec!["MIT".to_string(), "".to_string(), "GPL-3.0".to_string()],
             ignore: Vec::new(),
+            custom: Vec::new(),
         };
         let result = config.validate();
         assert!(result.is_err());
@@ -877,6 +976,7 @@ restrictive = [
                 "Apache-2.0".to_string(),
             ],
             ignore: Vec::new(),
+            custom: Vec::new(),
         };
         let result = config.validate();
         assert!(result.is_err());
@@ -895,7 +995,101 @@ restrictive = [
                 "SEE LICENSE IN LICENSE".to_string(),
             ],
             ignore: Vec::new(),
+            custom: Vec::new(),
         };
+        assert!(config.validate().is_ok());
+    }
+
+    fn custom_license_config(custom: Vec<CustomLicense>) -> LicenseConfig {
+        LicenseConfig {
+            custom,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_custom_license_validation_accepts_a_well_formed_rule() {
+        let config = custom_license_config(vec![CustomLicense {
+            id: "LicenseRef-acme-internal".to_string(),
+            match_all: vec!["ACME CONFIDENTIAL".to_string()],
+            restrictive: Some(true),
+        }]);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_custom_license_validation_rejects_a_markerless_rule() {
+        // No markers would match every license text and relabel the whole report.
+        let config = custom_license_config(vec![CustomLicense {
+            id: "LicenseRef-acme-internal".to_string(),
+            match_all: Vec::new(),
+            restrictive: None,
+        }]);
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("match_all"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_custom_license_validation_rejects_an_empty_marker() {
+        let config = custom_license_config(vec![CustomLicense {
+            id: "LicenseRef-acme-internal".to_string(),
+            match_all: vec!["ACME CONFIDENTIAL".to_string(), "  ".to_string()],
+            restrictive: None,
+        }]);
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_custom_license_validation_rejects_a_missing_id() {
+        let config = custom_license_config(vec![CustomLicense {
+            id: "  ".to_string(),
+            match_all: vec!["ACME CONFIDENTIAL".to_string()],
+            restrictive: None,
+        }]);
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("id"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_custom_license_validation_allows_repeated_ids() {
+        // Several wordings of one license share an id; that is the documented way to express OR.
+        let config = custom_license_config(vec![
+            CustomLicense {
+                id: "LicenseRef-acme-internal".to_string(),
+                match_all: vec!["ACME CONFIDENTIAL".to_string()],
+                restrictive: Some(true),
+            },
+            CustomLicense {
+                id: "LicenseRef-acme-internal".to_string(),
+                match_all: vec!["Acme Corp Internal License".to_string()],
+                restrictive: Some(true),
+            },
+        ]);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_custom_licenses_parse_from_toml() {
+        let toml = r#"
+[licenses]
+restrictive = ["GPL-3.0"]
+
+[[licenses.custom]]
+id = "LicenseRef-acme-internal"
+match_all = ["ACME CONFIDENTIAL", "Internal Use Only"]
+restrictive = true
+
+[[licenses.custom]]
+id = "AGPL-3.0"
+match_all = ["Cal.com, Inc."]
+"#;
+        let config: FeludaConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.licenses.custom.len(), 2);
+        assert_eq!(config.licenses.custom[0].id, "LicenseRef-acme-internal");
+        assert_eq!(config.licenses.custom[0].match_all.len(), 2);
+        assert_eq!(config.licenses.custom[0].restrictive, Some(true));
+        // `restrictive` omitted leaves classification to the usual rules.
+        assert_eq!(config.licenses.custom[1].restrictive, None);
         assert!(config.validate().is_ok());
     }
 
@@ -970,6 +1164,7 @@ restrictive = [
             licenses: LicenseConfig {
                 restrictive: vec!["MIT".to_string(), "GPL-3.0".to_string()],
                 ignore: Vec::new(),
+                custom: Vec::new(),
             },
             dependencies: DependencyConfig {
                 max_depth: 10,
@@ -986,6 +1181,7 @@ restrictive = [
             licenses: LicenseConfig {
                 restrictive: vec!["".to_string()], // Invalid empty license
                 ignore: Vec::new(),
+                custom: Vec::new(),
             },
             dependencies: DependencyConfig {
                 max_depth: 10,
@@ -1007,6 +1203,7 @@ restrictive = [
             licenses: LicenseConfig {
                 restrictive: vec!["MIT".to_string()],
                 ignore: Vec::new(),
+                custom: Vec::new(),
             },
             dependencies: DependencyConfig {
                 max_depth: 0,
@@ -1170,6 +1367,7 @@ ignore = []"#,
         let config = LicenseConfig {
             restrictive: vec!["GPL-3.0".to_string()],
             ignore: vec!["MIT".to_string(), "".to_string(), "Apache-2.0".to_string()],
+            custom: Vec::new(),
         };
         let result = config.validate();
         assert!(result.is_err());
@@ -1188,6 +1386,7 @@ ignore = []"#,
                 "Apache-2.0".to_string(),
                 "MIT".to_string(),
             ],
+            custom: Vec::new(),
         };
         let result = config.validate();
         assert!(result.is_err());
@@ -1201,6 +1400,7 @@ ignore = []"#,
         let config = LicenseConfig {
             restrictive: vec!["GPL-3.0".to_string(), "MIT".to_string()],
             ignore: vec!["MIT".to_string(), "Apache-2.0".to_string()],
+            custom: Vec::new(),
         };
         // Should pass validation but generate a warning
         assert!(config.validate().is_ok());
@@ -1211,6 +1411,7 @@ ignore = []"#,
         let config = LicenseConfig {
             restrictive: vec!["GPL-3.0".to_string(), "AGPL-3.0".to_string()],
             ignore: vec!["MIT".to_string(), "Apache-2.0".to_string()],
+            custom: Vec::new(),
         };
         assert!(config.validate().is_ok());
         assert_eq!(config.restrictive.len(), 2);
@@ -1256,6 +1457,7 @@ ignore = [
         let config = LicenseConfig {
             restrictive: vec!["GPL-3.0".to_string()],
             ignore: vec!["MIT".to_string(), "Apache-2.0".to_string()],
+            custom: Vec::new(),
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -1433,6 +1635,7 @@ reason = "All versions ignored"
             licenses: LicenseConfig {
                 restrictive: vec!["GPL-3.0".to_string()],
                 ignore: Vec::new(),
+                custom: Vec::new(),
             },
             dependencies: DependencyConfig {
                 max_depth: 10,

--- a/src/init.rs
+++ b/src/init.rs
@@ -99,6 +99,13 @@ restrictive = [
 # Licenses to skip from the scan entirely (e.g. internal or pre-approved deps).
 ignore = []
 
+# Teach feluda a license text its built-in rules cannot place, so it stops reporting
+# as Unknown. Every phrase in `match_all` must appear in the license file.
+# [[licenses.custom]]
+# id = "LicenseRef-acme-internal"
+# match_all = ["ACME CONFIDENTIAL", "Internal Use Only"]
+# restrictive = true   # omit to classify `id` the usual way
+
 [dependencies]
 # Maximum depth for transitive dependency resolution (1–100).
 max_depth = 10

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -718,6 +718,26 @@ pub fn is_license_restrictive(
     false
 }
 
+/// Whether a reported license value means "no license was resolved" rather than naming one.
+///
+/// Analyzers spell an unresolved license several ways depending on the ecosystem, and reports
+/// must not fold any of them in with the permissive licenses: "we could not tell" is not "it is
+/// fine" (issue #241).
+pub fn is_unresolved_license(license: Option<&str>) -> bool {
+    let Some(value) = license else {
+        return true;
+    };
+    let value = value.trim();
+    let lower = value.to_ascii_lowercase();
+    value.is_empty()
+        // Ruby, Java, .NET
+        || lower == "unknown"
+        // Node: "Unknown (failed to retrieve)"
+        || lower.starts_with("unknown (")
+        // Rust, and `LicenseInfo::get_license`'s rendering of `None`
+        || lower == "no license"
+}
+
 /// Check if a license should be ignored from analysis
 ///
 /// Returns true if the license is in the ignore list configured in `.feluda.toml`
@@ -1787,6 +1807,23 @@ mod tests {
 
         let result = detect_project_license(temp_dir.path().to_str().unwrap()).unwrap();
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_is_unresolved_license() {
+        // The three spellings analyzers use for "nothing resolved", plus casing and padding.
+        assert!(is_unresolved_license(None));
+        assert!(is_unresolved_license(Some("Unknown")));
+        assert!(is_unresolved_license(Some("unknown")));
+        assert!(is_unresolved_license(Some("No License")));
+        assert!(is_unresolved_license(Some("  no license  ")));
+        assert!(is_unresolved_license(Some("")));
+        assert!(is_unresolved_license(Some("Unknown (failed to retrieve)")));
+
+        assert!(!is_unresolved_license(Some("MIT")));
+        assert!(!is_unresolved_license(Some("GPL-3.0-or-later")));
+        // A real SPDX id that merely contains the word must not be swept up.
+        assert!(!is_unresolved_license(Some("LicenseRef-unknown-vendor")));
     }
 
     #[test]

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -600,6 +600,20 @@ fn is_single_license_restrictive(
     config: &config::FeludaConfig,
     strict: bool,
 ) -> bool {
+    // A user-defined definition that declares `restrictive` wins over both the registry and the
+    // `restrictive` list. Declaring one is how a project tells Feluda how to classify a license it
+    // does not know, or gets wrong, so the explicit answer has to beat the inferred ones (#21).
+    if let Some(declared) = custom_license_restrictiveness(license_str, config) {
+        log(
+            LogLevel::Info,
+            &format!(
+                "License {license_str} restrictiveness declared as {declared} by a custom \
+                 definition in .feluda.toml"
+            ),
+        );
+        return declared;
+    }
+
     // Registry keys are bare ids (`GPL-2.0`), so strip an SPDX `-only`/`-or-later`/`+`
     // modifier before the fallback lookup — suffixed ids must classify like their base
     // license (`GPL-2.0-or-later` is exactly as copyleft as `GPL-2.0`).
@@ -1212,6 +1226,61 @@ fn match_license_content(content: &str) -> Option<&'static str> {
     None
 }
 
+/// The user-defined license definitions from `.feluda.toml`.
+///
+/// Read per call, like [`is_license_restrictive`] and [`is_license_ignored`] alongside it. Callers
+/// reach this only after a license file has actually been read, so the call count tracks the
+/// number of license texts in a scan rather than the number of directories walked. Loading per
+/// call also keeps `feluda watch` honest: it re-scans in-process, so a cached snapshot would go on
+/// applying definitions the user has since edited away.
+fn custom_license_rules() -> Vec<config::CustomLicense> {
+    match config::load_config() {
+        Ok(cfg) => cfg.licenses.custom,
+        Err(e) => {
+            log_error("Error loading custom license definitions", &e);
+            Vec::new()
+        }
+    }
+}
+
+/// Return the id of the first user-defined license definition whose markers all appear in
+/// `content`, or `None` when no custom rule matches.
+fn match_custom_license_content(content: &str) -> Option<String> {
+    let rules = custom_license_rules();
+    let matched = rules.iter().find(|rule| {
+        // A markerless rule would match everything; `validate_custom` rejects those, but a
+        // config that failed to load must not turn into a catch-all either.
+        !rule.match_all.is_empty()
+            && rule
+                .match_all
+                .iter()
+                .all(|marker| content.contains(marker.as_str()))
+    })?;
+
+    log(
+        LogLevel::Info,
+        &format!(
+            "License text matched custom definition '{}' from .feluda.toml",
+            matched.id
+        ),
+    );
+    Some(matched.id.clone())
+}
+
+/// The declared restrictiveness of a custom license definition for `license_str`, if any rule
+/// names that id and sets `restrictive`.
+fn custom_license_restrictiveness(
+    license_str: &str,
+    config: &config::FeludaConfig,
+) -> Option<bool> {
+    config
+        .licenses
+        .custom
+        .iter()
+        .find(|rule| rule.id == license_str)
+        .and_then(|rule| rule.restrictive)
+}
+
 /// Detect a license's SPDX identifier from the **text content** of a license file
 /// (`LICENSE`, `COPYING`, …) or any blob of license text.
 ///
@@ -1219,7 +1288,13 @@ fn match_license_content(content: &str) -> Option<&'static str> {
 /// known license, or `None` otherwise. This is the single shared implementation that every
 /// language analyzer's local-license-file fallback routes through, so detection stays
 /// consistent (and SPDX-correct) across ecosystems.
+///
+/// User-defined definitions from `.feluda.toml` are tried before the built-in rules, so a project
+/// can both name a license Feluda does not know and correct one it places wrongly (issue #21).
 pub fn detect_license_from_content(content: &str) -> Option<String> {
+    if let Some(custom_id) = match_custom_license_content(content) {
+        return Some(custom_id);
+    }
     match_license_content(content).map(str::to_string)
 }
 
@@ -1387,6 +1462,10 @@ fn detect_spdx_header_in_dir(dir: &Path) -> Option<String> {
 /// files, then — only if none resolves — a bounded scan of the directory's source files for an
 /// `SPDX-License-Identifier:` header (see [`detect_spdx_header_in_dir`]). The header scan is a
 /// last resort, so a real license file always wins.
+///
+/// File contents go through [`detect_license_from_content`] rather than the built-in rules
+/// directly, so user-defined definitions from `.feluda.toml` apply here too. The one thing they
+/// cannot override is a filename with an implied id, which resolves before any content is read.
 pub fn detect_license_in_dir(dir: &Path) -> Option<String> {
     for entry in LICENSE_FILENAMES {
         let license_path = dir.join(entry.filename);
@@ -1401,8 +1480,8 @@ pub fn detect_license_in_dir(dir: &Path) -> Option<String> {
 
         match fs::read_to_string(&license_path) {
             Ok(content) => {
-                if let Some(spdx) = match_license_content(&content) {
-                    return Some(spdx.to_string());
+                if let Some(spdx) = detect_license_from_content(&content) {
+                    return Some(spdx);
                 }
             }
             Err(err) => {
@@ -2081,6 +2160,57 @@ mod tests {
         assert!(!is_license_restrictive(
             &Some("Apache-2.0".to_string()),
             &registry,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_custom_definition_overrides_registry_restrictiveness() {
+        // Issue #21: an explicit declaration beats both the registry and the restrictive list, in
+        // both directions. Exercised through `is_single_license_restrictive` because that is where
+        // the config is in hand; the end-to-end wiring is covered in tests/parser_integration.rs.
+        let registry = registry_with(&[
+            ("GPL-3.0", &["disclose-source"]),
+            ("MIT", &["include-copyright"]),
+        ]);
+        let declare = |id: &str, restrictive: Option<bool>| config::FeludaConfig {
+            licenses: config::LicenseConfig {
+                custom: vec![config::CustomLicense {
+                    id: id.to_string(),
+                    match_all: vec!["marker".to_string()],
+                    restrictive,
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Registry says restrictive, the declaration says otherwise.
+        assert!(!is_single_license_restrictive(
+            "GPL-3.0",
+            &registry,
+            &declare("GPL-3.0", Some(false)),
+            false
+        ));
+        // And the reverse: a permissive id a project wants flagged.
+        assert!(is_single_license_restrictive(
+            "MIT",
+            &registry,
+            &declare("MIT", Some(true)),
+            false
+        ));
+        // A bespoke id feluda knows nothing about resolves purely from the declaration.
+        assert!(is_single_license_restrictive(
+            "LicenseRef-acme-internal",
+            &registry,
+            &declare("LicenseRef-acme-internal", Some(true)),
+            false
+        ));
+        // Omitting `restrictive` leaves classification to the usual rules.
+        assert!(is_single_license_restrictive(
+            "GPL-3.0",
+            &registry,
+            &declare("GPL-3.0", None),
             false
         ));
     }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -1,6 +1,6 @@
 use crate::cli::{CiFormat, OsiFilter};
 use crate::debug::{log, log_debug, log_error, LogLevel};
-use crate::licenses::{LicenseCompatibility, LicenseInfo, OsiStatus};
+use crate::licenses::{is_unresolved_license, LicenseCompatibility, LicenseInfo, OsiStatus};
 use colored::*;
 use std::collections::HashMap;
 use std::fs;
@@ -634,12 +634,44 @@ fn print_incompatible_licenses_table(
     println!("{}\n", formatter.render_footer());
 }
 
+/// How the reported entries split across the summary's three buckets.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct LicenseTally {
+    permissive: usize,
+    restrictive: usize,
+    /// Entries whose license never resolved. These get their own bucket rather than padding the
+    /// permissive count: an unknown license is a review item, not a clean bill of health (#241).
+    unresolved: usize,
+}
+
+/// Split `license_info` into permissive, restrictive, and unresolved counts.
+///
+/// Restrictive wins over unresolved, so an entry that is restrictive *because* nothing resolved
+/// (unattributed vendored code, or any unknown license under `--strict`) is counted once, as
+/// restrictive. The three buckets therefore always sum to `license_info.len()`.
+fn tally_licenses(license_info: &[LicenseInfo]) -> LicenseTally {
+    let mut tally = LicenseTally::default();
+    for info in license_info {
+        if *info.is_restrictive() {
+            tally.restrictive += 1;
+        } else if is_unresolved_license(info.license.as_deref()) {
+            tally.unresolved += 1;
+        } else {
+            tally.permissive += 1;
+        }
+    }
+    tally
+}
+
 fn print_summary_footer(license_info: &[LicenseInfo], project_license: Option<&str>) {
     log(LogLevel::Info, "Printing summary footer");
 
     let total = license_info.len();
-    let restrictive_count = license_info.iter().filter(|i| *i.is_restrictive()).count();
-    let permissive_count = total - restrictive_count;
+    let LicenseTally {
+        permissive: permissive_count,
+        restrictive: restrictive_count,
+        unresolved: unresolved_count,
+    } = tally_licenses(license_info);
 
     // Calculate compatibility counts if project license is available
     let (compatible_count, incompatible_count, unknown_count) = if project_license.is_some() {
@@ -672,6 +704,13 @@ fn print_summary_footer(license_info: &[LicenseInfo], project_license: Option<&s
         restrictive_count.to_string().yellow().bold(),
         "restrictive licenses".yellow()
     );
+    if unresolved_count > 0 {
+        println!(
+            "  • {} {}",
+            unresolved_count.to_string().blue().bold(),
+            "unresolved licenses".blue()
+        );
+    }
 
     // Print compatibility info if project license is available
     if project_license.is_some() {
@@ -698,6 +737,13 @@ fn print_summary_footer(license_info: &[LicenseInfo], project_license: Option<&s
         println!("\n{} {}: Review these dependencies for compliance with your project's licensing requirements.",
             "⚠️".yellow().bold(),
             "Recommendation".yellow().bold()
+        );
+    } else if unresolved_count > 0 {
+        println!(
+            "\n{} {}: No restrictive licenses found, but {} could not be resolved. Check those manually.",
+            "🔎".blue().bold(),
+            "Recommendation".blue().bold(),
+            if unresolved_count == 1 { "1 dependency".to_string() } else { format!("{unresolved_count} dependencies") }
         );
     } else {
         println!(
@@ -1552,6 +1598,51 @@ mod tests {
         assert!(!incompatible_licenses.is_empty());
         print_incompatible_licenses_table(&incompatible_licenses, "MIT");
         // If no panic, test passes
+    }
+
+    #[test]
+    fn test_tally_licenses_keeps_unresolved_out_of_the_permissive_bucket() {
+        // Issue #241: "we could not resolve this" must not be reported as "this is permissive".
+        // The three spellings analyzers use for an unresolved license all land in one bucket.
+        let entry = |license: Option<&str>, is_restrictive: bool| LicenseInfo {
+            name: "pkg".to_string(),
+            version: "1.0.0".to_string(),
+            license: license.map(str::to_string),
+            is_restrictive,
+            compatibility: LicenseCompatibility::Unknown,
+            osi_status: OsiStatus::Unknown,
+            sub_project: None,
+        };
+
+        let tally = tally_licenses(&[
+            entry(Some("MIT"), false),
+            entry(Some("Apache-2.0"), false),
+            entry(Some("GPL-3.0"), true),
+            entry(None, false),
+            entry(Some("Unknown"), false),
+            entry(Some("No License"), false),
+            // Restrictive wins over unresolved so nothing is double-counted.
+            entry(None, true),
+        ]);
+
+        assert_eq!(
+            tally,
+            LicenseTally {
+                permissive: 2,
+                restrictive: 2,
+                unresolved: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn test_tally_licenses_buckets_sum_to_the_entry_count() {
+        let data = get_test_data();
+        let tally = tally_licenses(&data);
+        assert_eq!(
+            tally.permissive + tally.restrictive + tally.unresolved,
+            data.len()
+        );
     }
 
     #[test]

--- a/src/vendor_scan.rs
+++ b/src/vendor_scan.rs
@@ -9,6 +9,10 @@
 //!
 //! It is the directory-granularity companion to [`crate::source_scan`], which flags individual
 //! own-source files bearing a foreign license header.
+//!
+//! Findings here classify restrictiveness on a stricter rule than dependencies do: a directory
+//! with no resolvable license at all is restrictive even outside `--strict`. See
+//! [`scan_vendored_packages`] for why.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -352,7 +356,16 @@ pub fn scan_vendored_packages(
                 Some(license) => get_osi_status(license),
                 None => OsiStatus::Unknown,
             };
-            let is_restrictive = is_license_restrictive(&finding.license, &known_licenses, strict);
+            let is_restrictive = match &finding.license {
+                Some(_) => is_license_restrictive(&finding.license, &known_licenses, strict),
+                // A dependency whose license feluda could not fetch is a gap in *our* knowledge,
+                // so it stays non-restrictive outside `--strict`. A directory of code physically
+                // present in the tree with no license file and no SPDX header is a different
+                // claim: it is an observation about the code itself, and no license means no
+                // grant of permission. That is the highest-risk finding the scan produces, so it
+                // is restrictive regardless of `--strict` (issue #241).
+                None => true,
+            };
             LicenseInfo {
                 name: finding.path.display().to_string(),
                 version: finding.kind.marker().to_string(),
@@ -559,6 +572,38 @@ person obtaining a copy of this software and associated documentation files.\n";
         assert_eq!(results[0].version, VENDORED_MARKER);
         assert_eq!(results[0].license.as_deref(), Some("GPL-3.0"));
         assert_eq!(results[0].compatibility, LicenseCompatibility::Unknown);
+    }
+
+    #[test]
+    fn test_unlicensed_vendored_code_is_restrictive_without_strict() {
+        // Issue #241: copied-in code carrying no grant at all is the most restrictive case there
+        // is, so it must fail `--fail-on-restrictive` without the user opting into `--strict`.
+        let dir = tempfile::TempDir::new().unwrap();
+        let pkg = dir.path().join("third_party").join("mystery");
+        fs::create_dir_all(&pkg).unwrap();
+        fs::write(pkg.join("mystery.c"), "int main(void) { return 0; }\n").unwrap();
+
+        for strict in [false, true] {
+            let results = scan_vendored_packages(dir.path(), &[], None, strict);
+            assert_eq!(results.len(), 1);
+            assert!(results[0].license.is_none());
+            assert!(
+                *results[0].is_restrictive(),
+                "unlicensed vendored code must be restrictive (strict={strict})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_permissively_licensed_vendored_code_is_not_restrictive() {
+        // The #241 rule is scoped to a *missing* license; a resolved permissive one is unaffected.
+        let dir = tempfile::TempDir::new().unwrap();
+        write_license(&dir.path().join("vendor").join("leftpad"), MIT_TEXT);
+
+        let results = scan_vendored_packages(dir.path(), &[], None, false);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].license.as_deref(), Some("MIT"));
+        assert!(!*results[0].is_restrictive());
     }
 
     #[test]

--- a/tests/parser_integration.rs
+++ b/tests/parser_integration.rs
@@ -316,6 +316,8 @@ fn vendored_and_unmanaged_findings_reported() {
         mystery["license"].is_null(),
         "unattributed vendored code must report no license: {mystery:#?}"
     );
+    // Issue #241: no license means no grant of permission, so this is restrictive by default.
+    assert_eq!(mystery["is_restrictive"], true, "{mystery:#?}");
 
     let snippet = entry(&entries, "scripts/snippet");
     assert_eq!(snippet["version"], "unmanaged");
@@ -323,6 +325,40 @@ fn vendored_and_unmanaged_findings_reported() {
 
     // Manifest-declared dependencies are unaffected by the vendored pass.
     assert!(has_entry(&entries, "fixture-permissive"));
+}
+
+#[test]
+fn unattributed_vendored_code_fails_on_restrictive() {
+    // Issue #241, end to end: the highest-risk finding the scan produces must be able to stop a
+    // build without the user also passing --strict.
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    write_node_fixture(root, &[("fixture-permissive", "1.3.0", "ISC")]);
+
+    let bare = root.join("third_party").join("mystery");
+    fs::create_dir_all(&bare).unwrap();
+    fs::write(bare.join("mystery.c"), "int g(void) { return 1; }\n").unwrap();
+
+    let failing = run_feluda(root, &["--json", "--fail-on-restrictive"], &[]);
+    assert_eq!(
+        failing.status.code(),
+        Some(1),
+        "unlicensed vendored code must fail the scan\nstderr: {}",
+        String::from_utf8_lossy(&failing.stderr)
+    );
+
+    // Skipping the vendored pass leaves only the permissive manifest dependency, so it passes.
+    let passing = run_feluda(
+        root,
+        &["--json", "--fail-on-restrictive", "--no-vendor-scan"],
+        &[],
+    );
+    assert!(
+        passing.status.success(),
+        "--no-vendor-scan must drop the finding and the failure with it\nstderr: {}",
+        String::from_utf8_lossy(&passing.stderr)
+    );
 }
 
 #[test]

--- a/tests/parser_integration.rs
+++ b/tests/parser_integration.rs
@@ -327,6 +327,123 @@ fn vendored_and_unmanaged_findings_reported() {
     assert!(has_entry(&entries, "fixture-permissive"));
 }
 
+/// A license text none of the built-in content rules can place.
+const BESPOKE_LICENSE_TEXT: &str = "ACME CORPORATION SOFTWARE LICENSE\n\nThis software is ACME \
+CONFIDENTIAL and provided for Internal Use Only. Redistribution outside ACME is prohibited.\n";
+
+#[test]
+fn custom_license_definition_resolves_an_otherwise_unknown_license() {
+    // Issue #21: a user-defined definition in .feluda.toml names a license text feluda's
+    // built-in rules cannot identify, so it resolves instead of reporting as Unknown.
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    write_node_fixture(root, &[("fixture-permissive", "1.3.0", "ISC")]);
+
+    let vendored = root.join("vendor").join("acme-lib");
+    fs::create_dir_all(&vendored).unwrap();
+    fs::write(vendored.join("LICENSE"), BESPOKE_LICENSE_TEXT).unwrap();
+
+    // Without a definition the text does not resolve.
+    let baseline = scan_json(root, &[], &[]);
+    let before = entry(&baseline, "vendor/acme-lib");
+    assert!(
+        before["license"].is_null(),
+        "bespoke text must not resolve on its own: {before:#?}"
+    );
+
+    fs::write(
+        root.join(".feluda.toml"),
+        r#"
+[[licenses.custom]]
+id = "LicenseRef-acme-internal"
+match_all = ["ACME CONFIDENTIAL", "Internal Use Only"]
+restrictive = true
+"#,
+    )
+    .unwrap();
+
+    let entries = scan_json(root, &[], &[]);
+    let after = entry(&entries, "vendor/acme-lib");
+    assert_eq!(after["license"], "LicenseRef-acme-internal", "{after:#?}");
+    assert_eq!(after["is_restrictive"], true, "{after:#?}");
+}
+
+#[test]
+fn custom_license_definition_overrides_a_built_in_match() {
+    // The other half of #21: a definition also corrects a text the built-in rules place wrongly,
+    // which is what makes them usable on wrapped or reworded license files.
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    write_node_fixture(root, &[("fixture-permissive", "1.3.0", "ISC")]);
+
+    // An MIT text the project knows is actually its vendor's dual-license wrapper.
+    let vendored = root.join("vendor").join("wrapped-lib");
+    fs::create_dir_all(&vendored).unwrap();
+    fs::write(
+        vendored.join("LICENSE"),
+        format!("PORTIONS LICENSED SEPARATELY, SEE NOTICE\n\n{MIT_TEXT}"),
+    )
+    .unwrap();
+
+    fs::write(
+        root.join(".feluda.toml"),
+        r#"
+[[licenses.custom]]
+id = "LicenseRef-wrapped-dual"
+match_all = ["PORTIONS LICENSED SEPARATELY"]
+restrictive = true
+"#,
+    )
+    .unwrap();
+
+    let entries = scan_json(root, &[], &[]);
+    let found = entry(&entries, "vendor/wrapped-lib");
+    assert_eq!(
+        found["license"], "LicenseRef-wrapped-dual",
+        "the custom definition must win over the built-in MIT rule: {found:#?}"
+    );
+    assert_eq!(found["is_restrictive"], true, "{found:#?}");
+}
+
+#[test]
+fn custom_license_definition_can_declare_a_license_permissive() {
+    // `restrictive = false` is the escape hatch for an id feluda would otherwise flag, so the
+    // declaration has to beat the registry and the restrictive list in both directions.
+    let temp = tempfile::TempDir::new().unwrap();
+    let root = temp.path();
+    fs::write(root.join("LICENSE"), MIT_TEXT).unwrap();
+    write_node_fixture(root, &[("fixture-permissive", "1.3.0", "ISC")]);
+
+    let vendored = root.join("vendor").join("inhouse-gpl");
+    fs::create_dir_all(&vendored).unwrap();
+    fs::write(
+        vendored.join("LICENSE"),
+        "GNU GENERAL PUBLIC LICENSE\nVersion 3, 29 June 2007\n",
+    )
+    .unwrap();
+
+    fs::write(
+        root.join(".feluda.toml"),
+        r#"
+[[licenses.custom]]
+id = "GPL-3.0"
+match_all = ["GNU GENERAL PUBLIC LICENSE"]
+restrictive = false
+"#,
+    )
+    .unwrap();
+
+    let entries = scan_json(root, &[], &[]);
+    let found = entry(&entries, "vendor/inhouse-gpl");
+    assert_eq!(found["license"], "GPL-3.0");
+    assert_eq!(
+        found["is_restrictive"], false,
+        "an explicit declaration must override the registry: {found:#?}"
+    );
+}
+
 #[test]
 fn unattributed_vendored_code_fails_on_restrictive() {
     // Issue #241, end to end: the highest-risk finding the scan produces must be able to stop a


### PR DESCRIPTION
Two issues that turned out to be the same shape: what feluda should do when it cannot resolve a license.

Starting with #241, since it changes existing behaviour. A vendored or unmanaged directory with no license file and no resolvable SPDX header reported as non-restrictive unless `--strict` was set, so the highest-risk finding the #240 scan produces was the one least likely to fail a build. Settled on the asymmetric rule, with the full reasoning [recorded on the issue](https://github.com/anistark/feluda/issues/241#issuecomment-5102467927): an unresolved dependency license is a gap in feluda's own knowledge, so it stays non-restrictive by default and `--strict` still covers people who want the stricter reading. Code physically present in the tree with no grant at all is a different claim, an observation about the code itself rather than a failed lookup, and no license means no permission. Those classify restrictive regardless of `--strict`, so `--fail-on-restrictive` now stops a build on unattributed copied-in code out of the box. The cost is that "no license" means two things depending on where the row came from, which is why `docs/source/cli/scan.rst` spells out the asymmetry rather than leaving people to find it.

The adjacent question on that issue is fixed too: rows with no resolved license no longer count under "permissive licenses" in the summary, they get their own bucket. Pre-existing behaviour that the vendored scan just made visible. Analyzers spell an unresolved license four ways across ecosystems (`None`, `Unknown`, `Unknown (failed to retrieve)`, `No License`), so that check now lives in one shared `is_unresolved_license` helper instead of being re-guessed per call site, and the counting moved into a testable `tally_licenses`.

Then #21. Feluda's built-in content rules recognise the common license texts, but some projects ship one those rules cannot place, and those land in reports as Unknown. The issue's own example is cal.com's `LICENSE`: a custom preamble that grants AGPLv3 further down. A `[[licenses.custom]]` entry in `.feluda.toml` names the phrases that identify such a text and the id to report when they all appear, so that file resolves to `AGPL-3.0` with one rule instead of nothing.

Definitions are tried before the built-in rules, which is what makes them usable on wrapped or reworded license files, not just unknown ones. Repeating an id across entries expresses several wordings of one license, first match wins. The optional `restrictive` field beats both the license registry and the `restrictive` list, in either direction: a bespoke id feluda knows nothing about can still fail a build, which covers the pessimistic-output follow-up from #93, and a license legal has already cleared can stop being flagged without dropping the dependency from reports the way `ignore` does.

One thing fell out on the way. `detect_license_in_dir` called the built-in matcher directly rather than going through `detect_license_from_content`, so the single shared SPDX engine from v1.14.0 was not actually shared on the directory path that every analyzer and the vendored scan use. Routing it through the engine is what makes custom definitions reach vendored findings at all. Definitions are also read per call rather than cached, matching `is_license_restrictive` and `is_license_ignored` next to them: callers reach that code only after a license file has been read, so the call count tracks license texts rather than directories walked, and `feluda watch` re-scans in-process, so a cached snapshot would keep applying definitions the user had since edited away.

Closes #241
Closes #21
Refs #93
Refs #240
