### PR TITLE
feat(sbom): identify packages by ecosystem and PURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,9 @@ Sample Output for a sample cargo.toml file containing `serde` and `tokio` depend
     "license": "MIT",
     "is_restrictive": false,
     "compatibility": "Compatible",
-    "osi_status": "Approved"
+    "osi_status": "Approved",
+    "ecosystem": "cargo",
+    "purl": "pkg:cargo/serde@1.0.151"
   },
   {
     "name": "tokio",
@@ -475,7 +477,9 @@ Sample Output for a sample cargo.toml file containing `serde` and `tokio` depend
     "license": "MIT",
     "is_restrictive": false,
     "compatibility": "Compatible",
-    "osi_status": "Approved"
+    "osi_status": "Approved",
+    "ecosystem": "cargo",
+    "purl": "pkg:cargo/tokio@1.0.2"
   }
 ]
 ```
@@ -497,12 +501,16 @@ Sample Output for a sample cargo.toml file containing `serde` and `tokio` depend
   is_restrictive: false
   compatibility: Compatible
   osi_status: Approved
+  ecosystem: cargo
+  purl: pkg:cargo/serde@1.0.151
 - name: tokio
   version: 1.0.2
   license: MIT
   is_restrictive: false
   compatibility: Compatible
   osi_status: Approved
+  ecosystem: cargo
+  purl: pkg:cargo/tokio@1.0.2
 ```
 
 ### Gist Mode

--- a/docs/source/cli/output.rst
+++ b/docs/source/cli/output.rst
@@ -26,9 +26,26 @@ Machine-readable JSON for downstream automation.
    feluda --json
 
 Feluda emits a JSON array containing dependency names, versions, licenses,
-restriction flags, and OSI status. When scanning a workspace or monorepo, each
-entry also carries a ``sub_project`` field listing the workspace member(s) that
-pull in that dependency. The field is omitted on single-project scans.
+restriction flags, and OSI status. Each entry also carries the ``ecosystem`` it
+was resolved from and the ``purl`` (:ref:`package URL <output-purl>`) built from
+it. When scanning a workspace or monorepo, entries additionally carry a
+``sub_project`` field listing the workspace member(s) that pull in that
+dependency. That field is omitted on single-project scans.
+
+.. code-block:: text
+
+   [
+     {
+       "name": "serde",
+       "version": "1.0.219",
+       "license": "MIT",
+       "is_restrictive": false,
+       "compatibility": "Compatible",
+       "osi_status": "approved",
+       "ecosystem": "cargo",
+       "purl": "pkg:cargo/serde@1.0.219"
+     }
+   ]
 
 YAML Format
 ^^^^^^^^^^^
@@ -51,6 +68,57 @@ A one-line summary for dashboards or comment bots.
    feluda --gist
 
 Feluda condenses the report into a minimal single line.
+
+.. _output-purl:
+
+Package URLs
+^^^^^^^^^^^^
+
+A name and version identify a package only within one ecosystem: an npm
+``libssl3`` and a Debian package of the same name are different software. Every
+entry therefore carries a `package URL <https://github.com/package-url/purl-spec>`_
+of the form ``pkg:<type>/<namespace>/<name>@<version>``, which is unique across
+ecosystems and is what SBOM consumers key on.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Language
+     - ``ecosystem``
+     - Example ``purl``
+   * - Rust
+     - ``cargo``
+     - ``pkg:cargo/serde@1.0.219``
+   * - Node.js
+     - ``npm``
+     - ``pkg:npm/%40babel/core@7.24.0``
+   * - Go
+     - ``golang``
+     - ``pkg:golang/github.com/pkg/errors@v0.9.1``
+   * - Python
+     - ``pypi``
+     - ``pkg:pypi/flask-sqlalchemy@3.1.1``
+   * - Java
+     - ``maven``
+     - ``pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.17.0``
+   * - Ruby
+     - ``gem``
+     - ``pkg:gem/rails@7.1.3``
+   * - .NET
+     - ``nuget``
+     - ``pkg:nuget/Newtonsoft.Json@13.0.3``
+   * - R
+     - ``cran``
+     - ``pkg:cran/ggplot2@3.5.1``
+   * - C / C++
+     - ``conan``, ``generic``
+     - ``pkg:conan/fmt@10.2.1``, ``pkg:generic/libz@system``
+
+Names are normalized the way each ecosystem defines: npm and Go names are
+lowercased, Python names follow PEP 503, an npm scope and a Maven group become
+the PURL namespace. Findings from the source and vendored scans have no registry
+behind them and carry ``generic`` coordinates built from their path.
 
 **Options:**
 

--- a/docs/source/sbom/cyclonedx.rst
+++ b/docs/source/sbom/cyclonedx.rst
@@ -66,6 +66,19 @@ The generated CycloneDX document includes:
 - **Hashes** - SHA-256 and other integrity hashes when available
 - **Dependencies** - Dependency graph and relationships
 
+Every component carries a ``purl`` built from the ecosystem it was resolved
+from, so components stay identifiable across ecosystems:
+
+.. code-block:: text
+
+   {
+     "type": "library",
+     "name": "@babel/core",
+     "version": "7.24.0",
+     "purl": "pkg:npm/%40babel/core@7.24.0",
+     "licenses": [{"license": {"id": "MIT"}}]
+   }
+
 ----
 
 Example Output Structure

--- a/docs/source/sbom/spdx.rst
+++ b/docs/source/sbom/spdx.rst
@@ -62,9 +62,13 @@ The generated SPDX document includes:
 
 - **Document metadata** - Creator info, creation timestamp, SPDX version
 - **Package information** - Name, version, download location
+- **Package coordinates** - A ``PACKAGE-MANAGER`` external reference carrying the package's PURL
 - **License data** - SPDX license identifiers for each package
 - **Relationships** - Dependency relationships between packages
 - **Feluda metadata** - Tool version and scan parameters
+
+Each package's ``SPDXID`` is derived from its PURL, so two packages that share a
+name and version across ecosystems stay distinct elements in the document.
 
 ----
 
@@ -83,7 +87,21 @@ Example Output Structure
        "created": "2025-01-27T12:00:00Z",
        "creators": ["Tool: feluda-1.15.0"]
      },
-     "packages": []
+     "packages": [
+       {
+         "name": "github.com/gin-gonic/gin",
+         "SPDXID": "SPDXRef-Package-pkg090896e46f91ab5a",
+         "versionInfo": "v1.12.0",
+         "licenseDeclared": "MIT",
+         "externalRefs": [
+           {
+             "referenceCategory": "PACKAGE-MANAGER",
+             "referenceType": "purl",
+             "referenceLocator": "pkg:golang/github.com/gin-gonic/gin@v1.12.0"
+           }
+         ]
+       }
+     ]
    }
 
 ----

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1579,6 +1579,7 @@ pub fn handle_generate_command(
 mod tests {
     use super::*;
     use crate::licenses::LicenseCompatibility;
+    use crate::purl::Ecosystem;
     use tempfile::TempDir;
 
     fn get_test_license_data() -> Vec<LicenseInfo> {
@@ -1590,6 +1591,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1599,6 +1601,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ]
@@ -1837,6 +1840,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1846,6 +1850,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1855,6 +1860,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1902,6 +1908,7 @@ mod tests {
             is_restrictive: true,
             compatibility: LicenseCompatibility::Unknown,
             osi_status: crate::licenses::OsiStatus::Unknown,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1942,6 +1949,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1974,6 +1982,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1998,6 +2007,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 

--- a/src/languages/c.rs
+++ b/src/languages/c.rs
@@ -10,6 +10,7 @@ use crate::licenses::{
     detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 pub fn analyze_c_licenses(project_path: &str, config: &FeludaConfig) -> Vec<LicenseInfo> {
     log(
@@ -85,6 +86,7 @@ pub fn analyze_c_licenses(project_path: &str, config: &FeludaConfig) -> Vec<Lice
                     Some(l) => crate::licenses::get_osi_status(l),
                     None => crate::licenses::OsiStatus::Unknown,
                 },
+                ecosystem: Ecosystem::Generic,
                 sub_project: None,
             }
         })

--- a/src/languages/cpp.rs
+++ b/src/languages/cpp.rs
@@ -11,6 +11,7 @@ use crate::licenses::{
     detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 #[derive(Debug, Clone)]
 enum CppPackageManager {
@@ -19,6 +20,19 @@ enum CppPackageManager {
     CMake,
     Bazel,
     Unknown,
+}
+
+impl CppPackageManager {
+    /// The PURL ecosystem for packages declared through this package manager.
+    ///
+    /// Only Conan has a registered purl type; vcpkg, CMake and Bazel dependencies are named
+    /// without a registry behind them, so they carry generic coordinates.
+    fn ecosystem(&self) -> Ecosystem {
+        match self {
+            CppPackageManager::Conan => Ecosystem::Conan,
+            _ => Ecosystem::Generic,
+        }
+    }
 }
 
 pub fn analyze_cpp_licenses(project_path: &str, config: &FeludaConfig) -> Vec<LicenseInfo> {
@@ -58,6 +72,7 @@ pub fn analyze_cpp_licenses(project_path: &str, config: &FeludaConfig) -> Vec<Li
         &format!("Using max dependency depth: {max_depth}"),
     );
 
+    let ecosystem = package_manager.ecosystem();
     let all_deps = resolve_cpp_dependencies(
         project_path,
         &direct_dependencies,
@@ -104,6 +119,7 @@ pub fn analyze_cpp_licenses(project_path: &str, config: &FeludaConfig) -> Vec<Li
                     Some(l) => crate::licenses::get_osi_status(l),
                     None => crate::licenses::OsiStatus::Unknown,
                 },
+                ecosystem,
                 sub_project: None,
             }
         })

--- a/src/languages/dotnet.rs
+++ b/src/languages/dotnet.rs
@@ -12,6 +12,7 @@ use crate::licenses::{
     detect_license_from_content, detect_license_in_dir, fetch_licenses_from_github,
     is_license_restrictive, LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 #[derive(Debug, Clone)]
 pub struct NuGetPackage {
@@ -105,6 +106,7 @@ pub fn analyze_dotnet_licenses(project_path: &str, config: &FeludaConfig) -> Vec
                 Some(l) => crate::licenses::get_osi_status(l),
                 None => crate::licenses::OsiStatus::Unknown,
             },
+            ecosystem: Ecosystem::Nuget,
             sub_project: None,
         });
     }

--- a/src/languages/go.rs
+++ b/src/languages/go.rs
@@ -14,6 +14,7 @@ use crate::licenses::{
     detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 /// Go module names to exclude from dependency analysis
 /// These are special Go directives and built-in modules, not actual dependencies
@@ -99,6 +100,7 @@ pub fn analyze_go_licenses(go_mod_path: &str, config: &FeludaConfig) -> Vec<Lice
                 Some(l) => crate::licenses::get_osi_status(l),
                 None => crate::licenses::OsiStatus::Unknown,
             },
+            ecosystem: Ecosystem::Golang,
             sub_project: None,
         });
     }

--- a/src/languages/java.rs
+++ b/src/languages/java.rs
@@ -15,6 +15,7 @@ use crate::licenses::{
     detect_license_from_content, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 #[derive(Debug, Clone)]
 struct JavaDependency {
@@ -84,6 +85,7 @@ pub fn analyze_java_licenses(file_path: &str, config: &FeludaConfig) -> Vec<Lice
                 is_restrictive,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::get_osi_status(&license),
+                ecosystem: Ecosystem::Maven,
                 sub_project: None,
             }
         })

--- a/src/languages/node.rs
+++ b/src/languages/node.rs
@@ -11,6 +11,7 @@ use crate::licenses::{
     detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 /// Type alias for dependency detection
 type DependencyDetector = fn(&Path) -> Result<HashMap<String, String>, String>;
@@ -356,6 +357,7 @@ pub fn analyze_js_licenses_with_config(
                 is_restrictive,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::get_osi_status(&license),
+                ecosystem: Ecosystem::Npm,
                 sub_project,
             }
         })

--- a/src/languages/python.rs
+++ b/src/languages/python.rs
@@ -13,6 +13,7 @@ use crate::licenses::{
     detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 /// Represents an environment marker in a Python requirement
 /// Environment markers follow PEP 508 and are used to specify conditional dependencies
@@ -265,6 +266,7 @@ pub fn analyze_python_licenses(package_file_path: &str, config: &FeludaConfig) -
                                     Some(l) => crate::licenses::get_osi_status(l),
                                     None => crate::licenses::OsiStatus::Unknown,
                                 },
+                                ecosystem: Ecosystem::Pypi,
                                 sub_project,
                             });
                         }
@@ -354,6 +356,7 @@ pub fn analyze_python_licenses(package_file_path: &str, config: &FeludaConfig) -
                             Some(l) => crate::licenses::get_osi_status(l),
                             None => crate::licenses::OsiStatus::Unknown,
                         },
+                        ecosystem: Ecosystem::Pypi,
                         sub_project: None,
                     });
                 }

--- a/src/languages/r.rs
+++ b/src/languages/r.rs
@@ -10,6 +10,7 @@ use crate::licenses::{
     detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive, License,
     LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 pub fn analyze_r_licenses(package_file_path: &str, config: &FeludaConfig) -> Vec<LicenseInfo> {
     let mut licenses = Vec::new();
@@ -106,6 +107,7 @@ fn parse_renv_lock(
                                 Some(l) => crate::licenses::get_osi_status(l),
                                 None => crate::licenses::OsiStatus::Unknown,
                             },
+                            ecosystem: Ecosystem::Cran,
                             sub_project: None,
                         });
                     }
@@ -180,6 +182,7 @@ fn parse_description_file(
                         Some(l) => crate::licenses::get_osi_status(l),
                         None => crate::licenses::OsiStatus::Unknown,
                     },
+                    ecosystem: Ecosystem::Cran,
                     sub_project: None,
                 });
             }

--- a/src/languages/ruby.rs
+++ b/src/languages/ruby.rs
@@ -12,6 +12,7 @@ use crate::licenses::{
     detect_license_in_dir, fetch_licenses_from_github, is_license_restrictive,
     LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 #[derive(Debug, Clone)]
 struct RubyDependency {
@@ -74,6 +75,7 @@ pub fn analyze_ruby_licenses(file_path: &str, config: &FeludaConfig) -> Vec<Lice
                 is_restrictive,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::get_osi_status(&license),
+                ecosystem: Ecosystem::Gem,
                 sub_project: None,
             }
         })

--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -7,6 +7,7 @@ use crate::licenses::{
     detect_license_from_content, detect_license_in_dir, fetch_licenses_from_github,
     is_license_restrictive, LicenseCompatibility, LicenseInfo,
 };
+use crate::purl::Ecosystem;
 
 /// Analyze the licenses of Rust dependencies from Cargo packages
 #[allow(dead_code)]
@@ -202,6 +203,7 @@ pub fn analyze_rust_licenses_with_config(
                     Some(license) => crate::licenses::get_osi_status(license),
                     None => crate::licenses::OsiStatus::Unknown,
                 },
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             }
         })

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -18,6 +18,7 @@ use crate::cache;
 use crate::cli;
 use crate::config;
 use crate::debug::{log, log_debug, log_error, FeludaResult, LogLevel};
+use crate::purl::Ecosystem;
 
 static GITHUB_TOKEN: OnceLock<Option<String>> = OnceLock::new();
 
@@ -118,7 +119,10 @@ pub struct OsiLicenseInfo {
 }
 
 /// License Info of dependencies
-#[derive(Serialize, Debug, Clone)]
+///
+/// Serialization is written by hand rather than derived because `purl` is a derived field: it is
+/// computed from the ecosystem, name and version so it can never drift out of step with them.
+#[derive(Debug, Clone)]
 pub struct LicenseInfo {
     pub name: String,                        // The name of the software or library
     pub version: String,                     // The version of the software or library
@@ -126,8 +130,39 @@ pub struct LicenseInfo {
     pub is_restrictive: bool,    // A boolean indicating whether the license is restrictive or not
     pub compatibility: LicenseCompatibility, // Compatibility with project license
     pub osi_status: OsiStatus,   // OSI approval status
-    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ecosystem: Ecosystem,    // The packaging ecosystem the package was resolved from
     pub sub_project: Option<String>, // Workspace member that brought in this dependency (None for non-monorepos)
+}
+
+impl Serialize for LicenseInfo {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let purl = self.purl();
+        let mut len = 7;
+        if purl.is_some() {
+            len += 1;
+        }
+        if self.sub_project.is_some() {
+            len += 1;
+        }
+
+        let mut state = serializer.serialize_struct("LicenseInfo", len)?;
+        state.serialize_field("name", &self.name)?;
+        state.serialize_field("version", &self.version)?;
+        state.serialize_field("license", &self.license)?;
+        state.serialize_field("is_restrictive", &self.is_restrictive)?;
+        state.serialize_field("compatibility", &self.compatibility)?;
+        state.serialize_field("osi_status", &self.osi_status)?;
+        state.serialize_field("ecosystem", &self.ecosystem)?;
+        if let Some(ref purl) = purl {
+            state.serialize_field("purl", purl)?;
+        }
+        if let Some(ref sub_project) = self.sub_project {
+            state.serialize_field("sub_project", sub_project)?;
+        }
+        state.end()
+    }
 }
 
 impl LicenseInfo {
@@ -160,6 +195,13 @@ impl LicenseInfo {
 
     pub fn sub_project(&self) -> Option<&str> {
         self.sub_project.as_deref()
+    }
+
+    /// The package's PURL, the coordinate that identifies it across ecosystems.
+    ///
+    /// `None` only when the name is empty, which no analyzer should produce.
+    pub fn purl(&self) -> Option<String> {
+        self.ecosystem.purl(&self.name, &self.version)
     }
 
     #[allow(dead_code)]
@@ -1736,6 +1778,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         };
 
@@ -1755,10 +1798,59 @@ mod tests {
             is_restrictive: true,
             compatibility: LicenseCompatibility::Unknown,
             osi_status: OsiStatus::Unknown,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         };
 
         assert_eq!(info.get_license(), "No License");
+    }
+
+    #[test]
+    fn test_license_info_derives_its_purl_from_the_ecosystem() {
+        let npm = LicenseInfo {
+            name: "@babel/core".to_string(),
+            version: "7.24.0".to_string(),
+            license: Some("MIT".to_string()),
+            is_restrictive: false,
+            compatibility: LicenseCompatibility::Compatible,
+            osi_status: OsiStatus::Approved,
+            ecosystem: Ecosystem::Npm,
+            sub_project: None,
+        };
+
+        assert_eq!(npm.purl().as_deref(), Some("pkg:npm/%40babel/core@7.24.0"));
+
+        // Same name, different ecosystem, different package.
+        let cargo = LicenseInfo {
+            name: "core".to_string(),
+            ecosystem: Ecosystem::Cargo,
+            ..npm.clone()
+        };
+        assert_ne!(npm.purl(), cargo.purl());
+    }
+
+    #[test]
+    fn test_license_info_serializes_ecosystem_and_purl() {
+        let info = LicenseInfo {
+            name: "serde".to_string(),
+            version: "1.0.219".to_string(),
+            license: Some("MIT".to_string()),
+            is_restrictive: false,
+            compatibility: LicenseCompatibility::Compatible,
+            osi_status: OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
+            sub_project: None,
+        };
+
+        let json: serde_json::Value = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["name"], "serde");
+        assert_eq!(json["version"], "1.0.219");
+        assert_eq!(json["license"], "MIT");
+        assert_eq!(json["is_restrictive"], false);
+        assert_eq!(json["ecosystem"], "cargo");
+        assert_eq!(json["purl"], "pkg:cargo/serde@1.0.219");
+        // Unset optional fields stay out of the report, as before.
+        assert!(json.get("sub_project").is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod languages;
 mod licenses;
 mod manifest;
 mod parser;
+mod purl;
 mod reporter;
 mod sbom;
 mod source_scan;
@@ -363,11 +364,10 @@ fn analyze_dependencies(config: &CheckConfig) -> FeludaResult<(Vec<LicenseInfo>,
             "Skipping vendored/unmanaged dependency scan (--no-vendor-scan)",
         );
     } else {
-        let known_names: Vec<String> = analyzed_data.iter().map(|info| info.name.clone()).collect();
         let vendored_findings = cli::with_spinner("📦: vendored dependencies", |indicator| {
             let findings = vendor_scan::scan_vendored_packages(
                 Path::new(&config.path),
-                &known_names,
+                &analyzed_data,
                 project_license.as_deref(),
                 config.strict,
             );

--- a/src/purl.rs
+++ b/src/purl.rs
@@ -1,0 +1,333 @@
+//! Package ecosystem identity and PURL derivation.
+//!
+//! A package name and version identify a dependency only as long as every finding comes from one
+//! project's manifests. The moment findings can arrive from more than one ecosystem at a time, a
+//! Debian `libssl3` and an npm package of the same name are indistinguishable — to a reader of the
+//! report and, worse, to a consumer of the SBOM. [`Ecosystem`] records where a package came from,
+//! and the PURL built from it gives every package a coordinate that is unique across ecosystems.
+//!
+//! PURLs follow the [package-url spec](https://github.com/package-url/purl-spec):
+//! `pkg:<type>/<namespace>/<name>@<version>`. The namespace and the per-type name normalization
+//! are derived from the display name each analyzer already produces, so a Maven `group:artifact`,
+//! an npm `@scope/name`, and a Go module path all land in the right components.
+
+use serde::Serialize;
+
+/// The packaging ecosystem a package was resolved from.
+///
+/// The variant determines the PURL type and, with it, how the package's name is normalized and
+/// split into namespace and name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Ecosystem {
+    /// Rust crates (`Cargo.toml`).
+    Cargo,
+    /// Node.js packages (`package.json`).
+    Npm,
+    /// Go modules (`go.mod`).
+    Golang,
+    /// Python distributions (`requirements.txt`, `pyproject.toml`, ...).
+    Pypi,
+    /// Java artifacts (`pom.xml`, `build.gradle`).
+    Maven,
+    /// Ruby gems (`Gemfile`).
+    Gem,
+    /// .NET packages (`.csproj`, ...).
+    Nuget,
+    /// R packages (`DESCRIPTION`, `renv.lock`).
+    Cran,
+    /// C/C++ packages declared through Conan.
+    Conan,
+    // TODO: The three OS-package ecosystems below are reserved for the filesystem and container
+    // scanning phase of https://github.com/anistark/feluda/issues/247. They are part of the
+    // identity model now so the PURL type mapping does not have to change when that lands.
+    /// Debian and derivatives (`dpkg`).
+    #[allow(dead_code)]
+    Deb,
+    /// RPM-based distributions.
+    #[allow(dead_code)]
+    Rpm,
+    /// Alpine packages (`apk`).
+    #[allow(dead_code)]
+    Apk,
+    /// Anything without a package registry of its own: C/C++ deps from Makefiles, CMake, Bazel or
+    /// vcpkg, and the path-named findings the source and vendor scans produce.
+    Generic,
+}
+
+impl Ecosystem {
+    /// The PURL type string for this ecosystem, as registered in the purl spec.
+    pub fn purl_type(self) -> &'static str {
+        match self {
+            Ecosystem::Cargo => "cargo",
+            Ecosystem::Npm => "npm",
+            Ecosystem::Golang => "golang",
+            Ecosystem::Pypi => "pypi",
+            Ecosystem::Maven => "maven",
+            Ecosystem::Gem => "gem",
+            Ecosystem::Nuget => "nuget",
+            Ecosystem::Cran => "cran",
+            Ecosystem::Conan => "conan",
+            Ecosystem::Deb => "deb",
+            Ecosystem::Rpm => "rpm",
+            Ecosystem::Apk => "apk",
+            Ecosystem::Generic => "generic",
+        }
+    }
+
+    /// The package's PURL without a version: `pkg:<type>/<namespace>/<name>`.
+    ///
+    /// This is the package's identity independent of which version is installed, which is what
+    /// duplicate suppression compares. Returns `None` when the name carries nothing usable.
+    pub fn coordinates(self, name: &str) -> Option<String> {
+        let (namespace, name) = self.split_name(name)?;
+        let mut purl = format!("pkg:{}/", self.purl_type());
+        if let Some(namespace) = namespace {
+            purl.push_str(&namespace);
+            purl.push('/');
+        }
+        purl.push_str(&name);
+        Some(purl)
+    }
+
+    /// The package's full PURL: `pkg:<type>/<namespace>/<name>@<version>`.
+    ///
+    /// The version is dropped when it is empty, leaving a valid version-less PURL rather than a
+    /// trailing `@`.
+    pub fn purl(self, name: &str, version: &str) -> Option<String> {
+        let mut purl = self.coordinates(name)?;
+        let version = version.trim();
+        if !version.is_empty() {
+            purl.push('@');
+            purl.push_str(&encode_component(version));
+        }
+        Some(purl)
+    }
+
+    /// Split an analyzer's display name into an encoded `(namespace, name)` pair, applying the
+    /// name normalization the purl spec defines for this type.
+    fn split_name(self, name: &str) -> Option<(Option<String>, String)> {
+        let name = name.trim();
+        if name.is_empty() {
+            return None;
+        }
+
+        match self {
+            // Maven names are reported as `groupId:artifactId`; the group is the namespace.
+            Ecosystem::Maven => match name.split_once(':') {
+                Some((group, artifact)) if !group.is_empty() && !artifact.is_empty() => {
+                    Some((Some(encode_component(group)), encode_component(artifact)))
+                }
+                _ => Some((None, encode_component(name))),
+            },
+            // An npm scope is the namespace, and keeps its `@` (percent-encoded in canonical
+            // form): `@babel/core` becomes `pkg:npm/%40babel/core`.
+            Ecosystem::Npm => {
+                let lowered = name.to_lowercase();
+                match lowered.split_once('/') {
+                    Some((scope, package)) if !scope.is_empty() && !package.is_empty() => {
+                        Some((Some(encode_component(scope)), encode_component(package)))
+                    }
+                    _ => Some((None, encode_component(&lowered))),
+                }
+            }
+            // A Go module path is a namespace of path segments plus a final name, all lowercase.
+            Ecosystem::Golang => {
+                let lowered = name.to_lowercase();
+                let lowered = lowered.trim_matches('/');
+                match lowered.rsplit_once('/') {
+                    Some((namespace, package)) if !namespace.is_empty() && !package.is_empty() => {
+                        Some((Some(encode_path(namespace)), encode_component(package)))
+                    }
+                    _ => Some((None, encode_component(lowered))),
+                }
+            }
+            // PEP 503: lowercase, and every run of `-`, `_` or `.` collapses to a single `-`.
+            Ecosystem::Pypi => Some((None, encode_component(&normalize_pypi_name(name)))),
+            // Everything else is a flat, case-preserving name. Generic names are often paths, and
+            // encoding the whole string keeps a path from being mistaken for a namespace.
+            _ => Some((None, encode_component(name))),
+        }
+    }
+}
+
+impl std::fmt::Display for Ecosystem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.purl_type())
+    }
+}
+
+/// Whether a byte may appear literally in a PURL component (RFC 3986 unreserved characters).
+fn is_unreserved(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~')
+}
+
+/// Percent-encode a single PURL component. Operating on bytes keeps multi-byte UTF-8 correct.
+fn encode_component(component: &str) -> String {
+    let mut encoded = String::with_capacity(component.len());
+    for byte in component.bytes() {
+        if is_unreserved(byte) {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+/// Percent-encode a multi-segment namespace, leaving the `/` separators intact.
+fn encode_path(path: &str) -> String {
+    path.split('/')
+        .filter(|segment| !segment.is_empty())
+        .map(encode_component)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Normalize a Python distribution name per PEP 503.
+fn normalize_pypi_name(name: &str) -> String {
+    let mut normalized = String::with_capacity(name.len());
+    let mut last_was_separator = false;
+    for ch in name.to_lowercase().chars() {
+        if matches!(ch, '-' | '_' | '.') {
+            if !last_was_separator {
+                normalized.push('-');
+            }
+            last_was_separator = true;
+        } else {
+            normalized.push(ch);
+            last_was_separator = false;
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_purl_type_strings() {
+        assert_eq!(Ecosystem::Cargo.purl_type(), "cargo");
+        assert_eq!(Ecosystem::Golang.purl_type(), "golang");
+        assert_eq!(Ecosystem::Deb.purl_type(), "deb");
+        assert_eq!(Ecosystem::Generic.to_string(), "generic");
+    }
+
+    #[test]
+    fn test_simple_purls() {
+        assert_eq!(
+            Ecosystem::Cargo.purl("serde", "1.0.219").unwrap(),
+            "pkg:cargo/serde@1.0.219"
+        );
+        assert_eq!(
+            Ecosystem::Gem.purl("rails", "7.1.3").unwrap(),
+            "pkg:gem/rails@7.1.3"
+        );
+        assert_eq!(
+            Ecosystem::Nuget.purl("Newtonsoft.Json", "13.0.3").unwrap(),
+            "pkg:nuget/Newtonsoft.Json@13.0.3"
+        );
+        assert_eq!(
+            Ecosystem::Cran.purl("ggplot2", "3.5.1").unwrap(),
+            "pkg:cran/ggplot2@3.5.1"
+        );
+    }
+
+    #[test]
+    fn test_npm_scope_becomes_namespace() {
+        assert_eq!(
+            Ecosystem::Npm.purl("@babel/core", "7.24.0").unwrap(),
+            "pkg:npm/%40babel/core@7.24.0"
+        );
+        assert_eq!(
+            Ecosystem::Npm.purl("LeftPad", "1.0.0").unwrap(),
+            "pkg:npm/leftpad@1.0.0"
+        );
+    }
+
+    #[test]
+    fn test_golang_module_path_splits() {
+        assert_eq!(
+            Ecosystem::Golang
+                .purl("github.com/pkg/errors", "v0.9.1")
+                .unwrap(),
+            "pkg:golang/github.com/pkg/errors@v0.9.1"
+        );
+        assert_eq!(
+            Ecosystem::Golang
+                .purl("Gopkg.in/Yaml.v2", "v2.4.0")
+                .unwrap(),
+            "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+        );
+    }
+
+    #[test]
+    fn test_maven_coordinates_split_on_colon() {
+        assert_eq!(
+            Ecosystem::Maven
+                .purl("com.fasterxml.jackson.core:jackson-databind", "2.17.0")
+                .unwrap(),
+            "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.17.0"
+        );
+        // A name without a group still produces a usable PURL.
+        assert_eq!(
+            Ecosystem::Maven.purl("junit", "4.13.2").unwrap(),
+            "pkg:maven/junit@4.13.2"
+        );
+    }
+
+    #[test]
+    fn test_pypi_name_normalization() {
+        assert_eq!(
+            Ecosystem::Pypi.purl("Flask_SQLAlchemy", "3.1.1").unwrap(),
+            "pkg:pypi/flask-sqlalchemy@3.1.1"
+        );
+        assert_eq!(
+            Ecosystem::Pypi.purl("zope.interface", "6.2").unwrap(),
+            "pkg:pypi/zope-interface@6.2"
+        );
+    }
+
+    #[test]
+    fn test_percent_encoding() {
+        // Path-shaped generic names encode their separators, so a path is never read as a
+        // namespace.
+        assert_eq!(
+            Ecosystem::Generic
+                .purl("vendor/leftpad", "vendored")
+                .unwrap(),
+            "pkg:generic/vendor%2Fleftpad@vendored"
+        );
+        // Version constraints survive verbatim once encoded.
+        assert_eq!(
+            Ecosystem::Pypi.purl("requests", ">=2.0").unwrap(),
+            "pkg:pypi/requests@%3E%3D2.0"
+        );
+    }
+
+    #[test]
+    fn test_version_is_optional() {
+        assert_eq!(
+            Ecosystem::Cargo.purl("serde", "  ").unwrap(),
+            "pkg:cargo/serde"
+        );
+        assert_eq!(
+            Ecosystem::Cargo.coordinates("serde").unwrap(),
+            "pkg:cargo/serde"
+        );
+    }
+
+    #[test]
+    fn test_empty_name_has_no_purl() {
+        assert!(Ecosystem::Cargo.purl("", "1.0.0").is_none());
+        assert!(Ecosystem::Cargo.purl("   ", "1.0.0").is_none());
+    }
+
+    #[test]
+    fn test_same_name_across_ecosystems_is_distinct() {
+        let npm = Ecosystem::Npm.purl("libssl3", "3.0.0").unwrap();
+        let deb = Ecosystem::Deb.purl("libssl3", "3.0.0").unwrap();
+        assert_ne!(npm, deb);
+    }
+}

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -1251,6 +1251,7 @@ fn print_gist_summary(
 mod tests {
     use super::*;
     use crate::licenses::LicenseCompatibility;
+    use crate::purl::Ecosystem;
     use tempfile::TempDir;
 
     fn setup() -> TempDir {
@@ -1266,6 +1267,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1275,6 +1277,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1284,6 +1287,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1293,6 +1297,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::OsiStatus::Unknown,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ]
@@ -1307,6 +1312,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1316,6 +1322,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ]
@@ -1611,6 +1618,7 @@ mod tests {
             is_restrictive,
             compatibility: LicenseCompatibility::Unknown,
             osi_status: OsiStatus::Unknown,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         };
 
@@ -1695,6 +1703,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1704,6 +1713,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1736,6 +1746,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1745,6 +1756,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1777,6 +1789,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1786,6 +1799,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1817,6 +1831,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1838,6 +1853,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1859,6 +1875,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1889,6 +1906,7 @@ mod tests {
             is_restrictive: true,
             compatibility: LicenseCompatibility::Incompatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1961,6 +1979,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
         let temp_dir = setup();
@@ -2060,6 +2079,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -2079,6 +2099,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -2099,6 +2120,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -2108,6 +2130,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -2166,6 +2189,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
         print_workspace_breakdown(&data);
@@ -2183,6 +2207,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: Some("api, worker".into()),
             },
             LicenseInfo {
@@ -2192,6 +2217,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: Some("api".into()),
             },
         ];
@@ -2209,6 +2235,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: Some("api".into()),
         }];
         print_verbose_table(&data, false, Some("MIT"));

--- a/src/sbom/cyclonedx.rs
+++ b/src/sbom/cyclonedx.rs
@@ -253,6 +253,19 @@ fn convert_spdx_license_to_cyclonedx(spdx_license: &str) -> CycloneDxLicenseChoi
     }
 }
 
+/// Read a package's PURL back out of its SPDX package-manager external reference.
+///
+/// CycloneDX documents are produced by converting the SPDX document rather than from the analyzed
+/// dependencies directly, so the external reference written by `SpdxPackage::with_purl` is where
+/// the coordinate lives by the time we get here.
+fn purl_of(spdx_package: &crate::sbom::spdx::SpdxPackage) -> Option<String> {
+    spdx_package
+        .external_refs
+        .iter()
+        .find(|reference| reference.reference_type == "purl")
+        .map(|reference| reference.reference_locator.clone())
+}
+
 /// Convert SPDX document to CycloneDX BOM
 pub fn convert_spdx_to_cyclonedx(spdx_doc: &SpdxDocument) -> CycloneDxBom {
     let mut bom = CycloneDxBom::new();
@@ -267,7 +280,7 @@ pub fn convert_spdx_to_cyclonedx(spdx_doc: &SpdxDocument) -> CycloneDxBom {
             scope: Some("required".to_string()), // Default scope
             licenses: Vec::new(),
             copyright: spdx_package.copyright_text.clone(),
-            purl: None, // Could be enhanced in the future
+            purl: purl_of(spdx_package),
             external_references: Vec::new(),
         };
 
@@ -431,6 +444,40 @@ mod tests {
         assert_eq!(component.component_type, "library");
         assert_eq!(component.scope, Some("required".to_string()));
         assert!(!component.licenses.is_empty());
+    }
+
+    #[test]
+    fn test_component_carries_the_package_purl() {
+        let mut spdx_doc = SpdxDocument::new("test-project");
+        spdx_doc.add_package(
+            SpdxPackage::new("errors", &spdx_doc.document_namespace)
+                .with_version("v0.9.1")
+                .with_purl("pkg:golang/github.com/pkg/errors@v0.9.1")
+                .with_license("BSD-2-Clause"),
+        );
+
+        let bom = convert_spdx_to_cyclonedx(&spdx_doc);
+
+        assert_eq!(
+            bom.components[0].purl.as_deref(),
+            Some("pkg:golang/github.com/pkg/errors@v0.9.1")
+        );
+
+        let json = serde_json::to_string(&bom).unwrap();
+        assert!(json.contains("\"purl\":\"pkg:golang/github.com/pkg/errors@v0.9.1\""));
+    }
+
+    #[test]
+    fn test_component_without_a_purl_omits_the_field() {
+        let mut spdx_doc = SpdxDocument::new("test-project");
+        spdx_doc.add_package(
+            SpdxPackage::new("mystery", &spdx_doc.document_namespace).with_version("1.0.0"),
+        );
+
+        let bom = convert_spdx_to_cyclonedx(&spdx_doc);
+
+        assert_eq!(bom.components[0].purl, None);
+        assert!(!serde_json::to_string(&bom).unwrap().contains("\"purl\""));
     }
 
     #[test]

--- a/src/sbom/mod.rs
+++ b/src/sbom/mod.rs
@@ -39,6 +39,12 @@ pub fn handle_sbom_command(
         let mut package = SpdxPackage::new(dependency.name.clone(), &spdx_doc.document_namespace)
             .with_version(dependency.version.clone());
 
+        // The PURL is what keeps packages distinct across ecosystems, so it also supplies the
+        // package's SPDX identifier.
+        if let Some(purl) = dependency.purl() {
+            package = package.with_purl(purl);
+        }
+
         let force_noassertion = std::env::var("FELUDA_FORCE_NOASSERTION_LICENSES")
             .map(|v| v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);

--- a/src/sbom/spdx.rs
+++ b/src/sbom/spdx.rs
@@ -495,6 +495,32 @@ impl SpdxPackage {
         self
     }
 
+    /// Records the package's PURL and rebases the SPDX identifier on it.
+    ///
+    /// The identifier has to come from the PURL rather than from name and version, because those
+    /// two are not unique across ecosystems: a Debian `libssl3` and an npm package of the same
+    /// name and version would otherwise hash to the same `SPDXRef-`, collapsing two distinct
+    /// packages into one element and producing a document with duplicate identifiers.
+    ///
+    /// Call after [`Self::with_version`], which derives an identifier of its own.
+    pub fn with_purl(mut self, purl: impl Into<String>) -> Self {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let purl = purl.into();
+        let mut hasher = DefaultHasher::new();
+        purl.hash(&mut hasher);
+        let hash = hasher.finish();
+        self.spdx_id = format!("SPDXRef-Package-pkg{hash:016x}");
+
+        log(
+            LogLevel::Trace,
+            &format!("Generated SPDX ID '{}' from PURL '{purl}'", self.spdx_id),
+        );
+
+        self.add_external_ref("PACKAGE-MANAGER", "purl", purl)
+    }
+
     pub fn with_license(mut self, license: impl Into<String>) -> Self {
         let license = license.into();
         let spdx_license = convert_to_spdx_license_expression(&license);
@@ -623,7 +649,6 @@ impl SpdxPackage {
     /// ```ignore
     /// package.add_external_ref("PACKAGE_MANAGER", "npm", "lodash@4.17.21");
     /// ```
-    #[allow(dead_code)]
     pub fn add_external_ref(
         mut self,
         category: impl Into<String>,
@@ -1610,6 +1635,46 @@ mod tests {
 
         // Should be skipped due to invalid characters
         assert_eq!(package2.external_refs.len(), 0);
+    }
+
+    #[test]
+    #[serial]
+    fn test_purl_is_recorded_as_a_package_manager_external_ref() {
+        std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
+
+        let package = SpdxPackage::new("serde", "https://example.com/test")
+            .with_version("1.0.219")
+            .with_purl("pkg:cargo/serde@1.0.219");
+
+        assert_eq!(package.external_refs.len(), 1);
+        assert_eq!(
+            package.external_refs[0].reference_category,
+            "PACKAGE-MANAGER"
+        );
+        assert_eq!(package.external_refs[0].reference_type, "purl");
+        assert_eq!(
+            package.external_refs[0].reference_locator,
+            "pkg:cargo/serde@1.0.219"
+        );
+        assert!(is_valid_spdx_id_format(&package.spdx_id));
+    }
+
+    #[test]
+    #[serial]
+    fn test_same_name_and_version_across_ecosystems_stay_distinct() {
+        std::env::remove_var("FELUDA_FORCE_NOASSERTION_LICENSES");
+
+        let namespace = "https://example.com/test";
+        let npm = SpdxPackage::new("libssl3", namespace)
+            .with_version("3.0.0")
+            .with_purl("pkg:npm/libssl3@3.0.0");
+        let deb = SpdxPackage::new("libssl3", namespace)
+            .with_version("3.0.0")
+            .with_purl("pkg:deb/libssl3@3.0.0");
+
+        // Without the PURL both would hash from name and version alone and collide, leaving a
+        // document with two elements sharing one SPDXID.
+        assert_ne!(npm.spdx_id, deb.spdx_id);
     }
 
     #[test]

--- a/src/source_scan.rs
+++ b/src/source_scan.rs
@@ -23,6 +23,7 @@ use crate::licenses::{
     is_license_ignored, is_license_restrictive, read_header_region, LicenseCompatibility,
     LicenseInfo, SOURCE_HEADER_EXTENSIONS,
 };
+use crate::purl::Ecosystem;
 
 /// Marker placed in the version column of an own-source finding, distinguishing it from a
 /// dependency entry (files have no version).
@@ -222,6 +223,7 @@ pub fn scan_own_source_headers(
                 is_restrictive,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status,
+                ecosystem: Ecosystem::Generic,
                 sub_project: None,
             }
         })

--- a/src/table.rs
+++ b/src/table.rs
@@ -1472,6 +1472,7 @@ fn constraint_len_calculator(items: &[LicenseInfo]) -> (u16, u16, u16, u16, u16,
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::purl::Ecosystem;
 
     #[test]
     fn test_app_new() {
@@ -1482,6 +1483,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1515,6 +1517,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1524,6 +1527,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1533,6 +1537,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1575,6 +1580,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1613,6 +1619,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1622,6 +1629,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1661,6 +1669,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1679,6 +1688,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1688,6 +1698,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1697,6 +1708,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status: crate::licenses::OsiStatus::Unknown,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1716,6 +1728,7 @@ mod tests {
                 is_restrictive: true, // true
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1725,6 +1738,7 @@ mod tests {
                 is_restrictive: false, // false
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1774,6 +1788,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1783,6 +1798,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1806,6 +1822,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1815,6 +1832,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1824,6 +1842,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1851,6 +1870,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1860,6 +1880,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1885,6 +1906,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1894,6 +1916,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -1921,6 +1944,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1950,6 +1974,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -1981,6 +2006,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -1990,6 +2016,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -2019,6 +2046,7 @@ mod tests {
             is_restrictive: false,
             compatibility: LicenseCompatibility::Compatible,
             osi_status: crate::licenses::OsiStatus::Approved,
+            ecosystem: Ecosystem::Cargo,
             sub_project: None,
         }];
 
@@ -2040,6 +2068,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -2049,6 +2078,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -2058,6 +2088,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -2086,6 +2117,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -2095,6 +2127,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -2104,6 +2137,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];
@@ -2130,6 +2164,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -2139,6 +2174,7 @@ mod tests {
                 is_restrictive: false,
                 compatibility: LicenseCompatibility::Compatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
             LicenseInfo {
@@ -2148,6 +2184,7 @@ mod tests {
                 is_restrictive: true,
                 compatibility: LicenseCompatibility::Incompatible,
                 osi_status: crate::licenses::OsiStatus::Approved,
+                ecosystem: Ecosystem::Cargo,
                 sub_project: None,
             },
         ];

--- a/src/vendor_scan.rs
+++ b/src/vendor_scan.rs
@@ -14,7 +14,7 @@
 //! with no resolvable license at all is restrictive even outside `--strict`. See
 //! [`scan_vendored_packages`] for why.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use ignore::WalkBuilder;
@@ -25,6 +25,7 @@ use crate::licenses::{
     detect_license_in_dir, fetch_licenses_from_github, get_osi_status, is_license_ignored,
     is_license_restrictive, LicenseCompatibility, LicenseInfo, OsiStatus,
 };
+use crate::purl::Ecosystem;
 
 /// Marker placed in the version column of a package found inside a vendor directory.
 pub const VENDORED_MARKER: &str = "vendored";
@@ -172,25 +173,65 @@ fn enclosing_vendor_dir(path: &Path, root: &Path) -> Option<PathBuf> {
 /// The name a vendored package would carry in a manifest, used to suppress duplicates.
 ///
 /// `go mod vendor` copies dependencies that `go.mod` already lists, so `vendor/github.com/pkg/errors`
-/// is normally reported by the Go analyzer too. Both the module-path form
-/// (`github.com/pkg/errors`) and the bare directory name (`errors`) are candidates, since
-/// ecosystems differ in which one lands in the manifest.
-fn dependency_name_candidates(path: &Path, vendor_root: &Path) -> Vec<String> {
-    let mut candidates = Vec::new();
-    if let Ok(rel) = path.strip_prefix(vendor_root) {
-        let joined = rel
-            .components()
-            .filter_map(|c| c.as_os_str().to_str())
-            .collect::<Vec<_>>()
-            .join("/");
-        if !joined.is_empty() {
-            candidates.push(joined);
+/// is normally reported by the Go analyzer too. The path below the vendor directory is that name:
+/// vendor tools lay a package out under the identifier its ecosystem knows it by, whether that is
+/// a bare `leftpad`, a scoped `@babel/core`, or a full module path.
+///
+/// Only the whole path counts, never its last segment on its own. `errors` names a different
+/// package from `github.com/pkg/errors`, and matching the tail would let any dependency called
+/// `errors` hide a vendored copy of the Go module.
+fn dependency_name_candidate(path: &Path, vendor_root: &Path) -> Option<String> {
+    let rel = path.strip_prefix(vendor_root).ok()?;
+    let joined = rel
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>()
+        .join("/");
+    (!joined.is_empty()).then_some(joined)
+}
+
+/// The packages the manifests already account for, indexed by PURL coordinates.
+///
+/// Matching on the bare name alone conflates ecosystems: an npm package called `errors` would
+/// suppress a vendored copy of Go's `github.com/pkg/errors`. Keying on the versionless PURL keeps
+/// the two apart, because the coordinate carries the package type. Comparison is
+/// case-insensitive, since a vendor directory is named by whoever copied the code in and rarely
+/// matches the manifest's capitalization.
+struct KnownPackages {
+    /// Versionless PURLs of everything the analyzers reported, lowercased.
+    coordinates: HashSet<String>,
+    /// The distinct ecosystems present, used to build the coordinates a candidate could have.
+    ecosystems: Vec<Ecosystem>,
+}
+
+impl KnownPackages {
+    fn new(known_dependencies: &[LicenseInfo]) -> Self {
+        let mut coordinates = HashSet::new();
+        let mut ecosystems: Vec<Ecosystem> = Vec::new();
+
+        for dependency in known_dependencies {
+            if let Some(coordinate) = dependency.ecosystem.coordinates(&dependency.name) {
+                coordinates.insert(coordinate.to_lowercase());
+            }
+            if !ecosystems.contains(&dependency.ecosystem) {
+                ecosystems.push(dependency.ecosystem);
+            }
+        }
+
+        Self {
+            coordinates,
+            ecosystems,
         }
     }
-    if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-        candidates.push(name.to_string());
+
+    /// Whether `candidate` names a package a manifest already reported, in any ecosystem in play.
+    fn covers(&self, candidate: &str) -> bool {
+        self.ecosystems.iter().any(|ecosystem| {
+            ecosystem
+                .coordinates(candidate)
+                .is_some_and(|coordinate| self.coordinates.contains(&coordinate.to_lowercase()))
+        })
     }
-    candidates
 }
 
 /// Walk the project tree and return every directory holding code no manifest records.
@@ -201,13 +242,10 @@ fn dependency_name_candidates(path: &Path, vendor_root: &Path) -> Vec<String> {
 /// once per nested subdirectory.
 fn collect_findings(
     root: &Path,
-    known_dependencies: &[String],
+    known_dependencies: &[LicenseInfo],
     project_license: Option<&str>,
 ) -> Vec<Finding> {
-    let known: Vec<String> = known_dependencies
-        .iter()
-        .map(|name| name.to_lowercase())
-        .collect();
+    let known = KnownPackages::new(known_dependencies);
 
     let walker = WalkBuilder::new(root)
         .sort_by_file_path(|a, b| a.cmp(b))
@@ -256,9 +294,8 @@ fn collect_findings(
                 if license.is_none() && !contains_files(path) {
                     continue;
                 }
-                if dependency_name_candidates(path, &vendor_root)
-                    .iter()
-                    .any(|candidate| known.contains(&candidate.to_lowercase()))
+                if dependency_name_candidate(path, &vendor_root)
+                    .is_some_and(|candidate| known.covers(&candidate))
                 {
                     log(
                         LogLevel::Info,
@@ -323,8 +360,9 @@ fn collect_findings(
 /// Scan the project tree for vendored and otherwise unmanaged dependencies and return them as
 /// [`LicenseInfo`] entries ready to be appended to the dependency report.
 ///
-/// `known_dependencies` are the names the language analyzers already reported; a vendored
-/// directory matching one of them is suppressed so `go mod vendor` trees are not reported twice.
+/// `known_dependencies` are the packages the language analyzers already reported; a vendored
+/// directory whose PURL coordinates match one of them is suppressed so `go mod vendor` trees are
+/// not reported twice.
 /// `project_license` suppresses stray license files that merely restate the project's own license.
 ///
 /// Compatibility is left [`LicenseCompatibility::Unknown`]; the caller's compatibility
@@ -332,7 +370,7 @@ fn collect_findings(
 /// fetched only when at least one finding exists, so clean projects pay nothing.
 pub fn scan_vendored_packages(
     root: &Path,
-    known_dependencies: &[String],
+    known_dependencies: &[LicenseInfo],
     project_license: Option<&str>,
     strict: bool,
 ) -> Vec<LicenseInfo> {
@@ -373,6 +411,7 @@ pub fn scan_vendored_packages(
                 is_restrictive,
                 compatibility: LicenseCompatibility::Unknown,
                 osi_status,
+                ecosystem: Ecosystem::Generic,
                 sub_project: None,
             }
         })
@@ -399,6 +438,20 @@ person obtaining a copy of this software and associated documentation files.\n";
             .iter()
             .map(|f| f.path.display().to_string().replace('\\', "/"))
             .collect()
+    }
+
+    /// A package as an analyzer would have reported it, for duplicate-suppression tests.
+    fn manifest_package(ecosystem: Ecosystem, name: &str) -> LicenseInfo {
+        LicenseInfo {
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            license: Some("MIT".to_string()),
+            is_restrictive: false,
+            compatibility: LicenseCompatibility::Unknown,
+            osi_status: OsiStatus::Approved,
+            ecosystem,
+            sub_project: None,
+        }
     }
 
     #[test]
@@ -463,7 +516,8 @@ person obtaining a copy of this software and associated documentation files.\n";
         let dir = tempfile::TempDir::new().unwrap();
         write_license(&dir.path().join("vendor/github.com/pkg/errors"), MIT_TEXT);
 
-        let findings = collect_findings(dir.path(), &["github.com/pkg/errors".to_string()], None);
+        let known = [manifest_package(Ecosystem::Golang, "github.com/pkg/errors")];
+        let findings = collect_findings(dir.path(), &known, None);
         assert!(findings.is_empty());
     }
 
@@ -472,8 +526,21 @@ person obtaining a copy of this software and associated documentation files.\n";
         let dir = tempfile::TempDir::new().unwrap();
         write_license(&dir.path().join("vendor").join("leftpad"), MIT_TEXT);
 
-        let findings = collect_findings(dir.path(), &["LeftPad".to_string()], None);
+        let known = [manifest_package(Ecosystem::Npm, "LeftPad")];
+        let findings = collect_findings(dir.path(), &known, None);
         assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_manifest_package_from_another_ecosystem_does_not_suppress() {
+        // A vendored Go module and an npm package can share a bare name; keying suppression on
+        // the PURL keeps the vendored copy visible.
+        let dir = tempfile::TempDir::new().unwrap();
+        write_license(&dir.path().join("vendor/github.com/pkg/errors"), MIT_TEXT);
+
+        let known = [manifest_package(Ecosystem::Npm, "errors")];
+        let findings = collect_findings(dir.path(), &known, None);
+        assert_eq!(names(&findings), vec!["vendor/github.com/pkg/errors"]);
     }
 
     #[test]


### PR DESCRIPTION
`LicenseInfo` identified a package by name and version. That is enough while every finding comes from a language manifest inside one project, and it breaks as soon as findings can come from more than one ecosystem at a time: a Debian `libssl3` and an npm package of the same name are the same row to the report and the same element to an SBOM consumer. Every later phase of #247 needs this, so it lands first. It also closes a standing gap, since the CycloneDX writer hardcoded `purl: None` and feluda's SBOMs carried no package coordinates at all.

`src/purl.rs` holds the model. `Ecosystem` covers cargo, npm, golang, pypi, maven, gem, nuget, cran, conan and generic, with `deb`, `rpm` and `apk` present but never constructed yet, so the type mapping does not have to change when container and filesystem scanning lands. Most of the work is the per type normalization the [purl
spec](https://github.com/package-url/purl-spec) defines: a Maven `group:artifact` splits on the colon, an npm scope becomes a `%40` encoded namespace, a Go module path splits at its last segment and lowercases, Python names follow PEP 503.

`LicenseInfo` gains one field, `ecosystem`. The PURL is derived from it rather than stored, so it cannot drift from the name and version it is built from, and the cost is a hand written `Serialize` impl, since serde's derive has no computed fields. Reports gain `ecosystem` and `purl`; every existing field is untouched.

`SpdxPackage::with_purl` writes the `PACKAGE-MANAGER` external ref and also rebases the `SPDXID` on a hash of the PURL. The rebase is the part that matters: `with_version` hashed name and version, so two same named packages at one version from different ecosystems produced a single SPDXID for two elements, which is an invalid document. CycloneDX reads the coordinate back out of that external ref, since it converts from the SPDX document rather than from `LicenseInfo`.

The #240 duplicate suppression now matches a vendored directory against known PURL coordinates instead of bare names, and one behaviour changes with it: the trailing directory name on its own is no longer a candidate. Matching the tail is exactly what let any dependency called `errors` hide a vendored copy of `github.com/pkg/errors`, so keeping it would have defeated the point. The vendor relative path is still matched case insensitively, because a vendor directory is named by whoever copied the code in and rarely matches the manifest's capitalization.

Closes #248
Refs #247
Refs #240