### PR TITLE
feat(licenses): resolve unknown licenses from ClearlyDefined

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,9 @@ src/filesystem/ — catalog what a root filesystem has installed: OS packages fr
                   rpm's sqlite header store, plus installed language artifacts
                   (site-packages, node_modules)
         ↓
+src/clearlydefined.rs — last resort for findings still unresolved: batch-ask
+                        ClearlyDefined by package coordinate, then reclassify
+        ↓
 src/licenses.rs — enrich with compatibility, OSI status, restrictiveness
         ↓
 src/reporter.rs — format output (text/JSON/YAML/CI/gist)
@@ -67,7 +70,7 @@ src/reporter.rs — format output (text/JSON/YAML/CI/gist)
 
 ### Critical Rules
 
-1. **Local-first license resolution.** Feluda checks local files before making network requests. The `--no-local` flag overrides this. Respect this order in all language parsers.
+1. **Local-first license resolution.** Feluda checks local files before making network requests. The `--no-local` flag overrides this. Respect this order in all language parsers. ClearlyDefined comes last, after everything else has failed — never make it a first choice.
 
 2. **GitHub API rate limits matter.** Unauthenticated: 60 req/hr. Authenticated (`--github-token`): 5,000 req/hr. Never make unnecessary API calls. Use the cache system (`src/cache.rs`).
 
@@ -140,7 +143,8 @@ src/
 ├── licenses.rs          # License analysis, compatibility, OSI status, GitHub API
 ├── source_scan.rs       # Own-source license header findings (default scan)
 ├── vendor_scan.rs       # Vendored/unmanaged dependency findings (default scan)
-├── cache.rs             # GitHub license data caching (.feluda/cache/)
+├── clearlydefined.rs    # Last-resort license lookup for unresolved findings
+├── cache.rs             # GitHub license table + ClearlyDefined answer caching
 ├── reporter.rs          # Text/JSON/YAML/CI/gist output formatting
 ├── table.rs             # TUI mode (ratatui)
 ├── generate.rs          # NOTICE / THIRD_PARTY_LICENSES file generation
@@ -189,13 +193,14 @@ src/
 
 - **Language detection via file patterns.** `src/languages/mod.rs` defines `Language::from_file_name()` which maps manifest filenames to language variants. `src/parser.rs` scans the project root for these files.
 - **Parallel analysis.** Multiple project roots are analyzed in parallel using `rayon`.
-- **Two-tier license resolution.** Local files are checked first (e.g., `node_modules/*/LICENSE`, `Cargo.toml` license field), then GitHub API as fallback. The `--no-local` flag skips local checks.
+- **Three-tier license resolution.** Local files are checked first (e.g., `node_modules/*/LICENSE`, `Cargo.toml` license field), then the ecosystem's registry or the GitHub API, then ClearlyDefined for whatever is still unresolved. The `--no-local` flag skips the first tier, `--no-clearlydefined` skips the last.
 - **Three ways in, one pipeline.** The manifest scan, `--sbom-input` and `--filesystem` all produce a `Vec<LicenseInfo>`; everything downstream (compatibility, filters, reports, exit codes) is shared. A package's identity is its `Ecosystem` + PURL (`src/purl.rs`), which is what lets findings from different ecosystems coexist in one report. Sources that build findings themselves rather than through a language analyzer finish with `licenses::classify_findings`, so restrictiveness and OSI status are decided identically whatever discovered the package.
 - **OS packages carry their distro in the name.** A cataloged package is named `debian/libssl3`, which is what puts the namespace in its PURL (`pkg:deb/debian/libssl3`). This mirrors how maven, npm and golang names already carry their namespace. PURL qualifiers (`arch`, `distro`) are deliberately not emitted, because `parse_purl` deliberately drops them on read.
 - **Installed artifacts are deduped by file ownership, never by name.** dpkg's `/var/lib/dpkg/info/*.list`, apk's `F:`/`R:` records and rpm's `DIRNAMES`/`DIRINDEXES`/`BASENAMES` tags say which files belong to which package, so an artifact a distro package already ships is suppressed exactly. The OS catalogers filter those file lists through `filesystem::artifacts::is_artifact_metadata` as they read them, so only the handful of relevant paths are held in memory. Adding a new artifact cataloger means teaching that one function about its metadata file, and the ownership check follows for free.
 - **The rpm database is read without a SQLite dependency.** `filesystem/rpm/sqlite.rs` is a read-only b-tree reader for the one table rpm keeps headers in. This is deliberate: linking `rusqlite` (bundled) would put a C toolchain in front of every target in `release-binaries.yml`, and the `sqlite3` CLI is not guaranteed on the host. Don't replace it with either. Only the sqlite backend is read; ndb and Berkeley DB are detected and reported by name.
 - **Registry lookups have one home each.** `languages::resolve_license_for(ecosystem, name, version)` dispatches to the lookup its analyzer already uses. Add a new registry client to the language module, not to the dispatcher.
-- **Caching.** GitHub API responses are cached in `.feluda/cache/github_licenses.json` with 30-day expiration.
+- **ClearlyDefined is the exception, and deliberately not a language module.** It answers for every ecosystem at once, so it lives in `src/clearlydefined.rs` and runs as a pass over finished findings rather than inside an analyzer: `resolve_unknown_licenses(&mut findings, strict)` picks out what is still unresolved, maps it onto a ClearlyDefined coordinate, asks in one batch, and reclassifies what it fills in. Each scan source calls it once where its findings are final — the SBOM ingest before it writes the enriched copy, `scan_filesystem` after `classify_findings`, and `analyze_dependencies` at the end of the manifest branch. It returns the indices it changed, which is how the enriched SBOM knows what to write back. Only `licensed.declared` is read; the per-file scan results in the same document describe fixtures and vendored code inside the package.
+- **Caching.** Two files in the user cache directory (`~/Library/Caches/feluda`, `$XDG_CACHE_HOME/feluda`, `%LOCALAPPDATA%\feluda`): `github_licenses.json` for the GitHub license table (30 days) and `clearlydefined.json` for ClearlyDefined answers (7 days, misses cached too). Both go through the generic `load_cache`/`save_cache` pair in `src/cache.rs`; `feluda cache` reports both and `--clear` removes both.
 - **Configuration layering.** `figment` merges defaults → `.feluda.toml` → environment variables. See `src/config.rs`.
 - **Error handling.** `thiserror`-based `FeludaError` in `src/debug.rs` with `FeludaResult<T>` alias. Debug mode (`--debug`) enables verbose logging.
 
@@ -295,6 +300,8 @@ cargo run -- --path examples/python-example
 ## Testing
 
 - **Unit tests** live alongside source code (standard Rust `#[cfg(test)]` modules).
+- **Integration tests** in `tests/` drive the real binary (`CARGO_BIN_EXE_feluda`) against fixtures built in temp directories. They must pass offline: fixtures are crafted so licenses resolve locally, and every harness sets `FELUDA_CLEARLYDEFINED_ENABLED=false` so the suite never depends on a third party service. Keep that env var on any new harness that runs the binary.
+- **Testing something that talks to the network** — point it at a stub server rather than the real one. `tests/clearlydefined_integration.rs` runs a `TcpListener` on localhost and sets `FELUDA_CLEARLYDEFINED_ENDPOINT`; it also gives each run its own `HOME`/`XDG_CACHE_HOME`, since a cached answer would otherwise mean the stub is never called. Live checks against the real service go behind `#[ignore]`.
 - **Dev dependencies** include `tempfile`, `mockall`, `http`, `temp-env`, `serial_test`.
 - Always run `cargo test` before committing.
 - The CI expects zero clippy warnings: `cargo clippy --all-targets --all-features -- -D warnings`.
@@ -390,6 +397,7 @@ feluda cache --clear                      # Clear cache
 feluda --github-token <token>             # Authenticated API requests
 feluda --no-local                         # Skip local license detection
 feluda --no-vendor-scan                   # Skip the vendored/unmanaged tree walk
+feluda --no-clearlydefined                # Skip the ClearlyDefined lookup for unresolved licenses
 feluda --strict                           # Strict license parsing
 feluda --debug                            # Enable debug logging
 ```
@@ -415,11 +423,12 @@ feluda --debug                            # Enable debug logging
 | `src/sbom/ingest.rs` | SBOM ingest (`--sbom-input`), the non-manifest scan source |
 | `src/filesystem/mod.rs` | Filesystem scan (`--filesystem`), the installed-tree scan source |
 | `src/purl.rs` | `Ecosystem` enum, PURL building and parsing |
-| `src/cache.rs` | GitHub license data caching |
+| `src/clearlydefined.rs` | ClearlyDefined fallback for licenses nothing else resolved |
+| `src/cache.rs` | GitHub license table and ClearlyDefined answer caching |
 | `config/license_compatibility.toml` | License compatibility matrix |
 | `action.yml` | GitHub Action definition |
 | `justfile` | All development task commands |
-| `.feluda.toml` | User configuration (restrictive overrides, ignores) |
+| `.feluda.toml` | User configuration (restrictive overrides, ignores, custom licenses, ClearlyDefined toggle) |
 | `skills/feluda/SKILL.md` | Claude Code skill — install in any project to get auto license checks |
 
 ---
@@ -482,6 +491,8 @@ feluda --debug                            # Enable debug logging
 - **clippy must pass with zero warnings** — CI enforces `-D warnings`.
 - **The `--debug` flag controls logging.** All `log()`, `log_debug()`, `log_error()` calls in `src/debug.rs` are no-ops unless `--debug` is active.
 - **`reqwest` is in blocking mode.** Despite `tokio` being a dependency, HTTP calls use `reqwest::blocking`. This is intentional for CLI simplicity.
+- **The ClearlyDefined API needs HTTP/1.1.** It accepts an HTTP/2 POST and never answers it, so its client sets `http1_only()`. It also intermittently hangs on HTTP/1.1 (accepts the request, never responds), which is why that client has a short timeout, one retry on a fresh connection, and gives up on the run after a batch fails twice. Don't remove either without testing against the live service.
+- **Two tests depend on the GitHub license table.** The apk and rpm filesystem integration tests assert GPL packages classify as restrictive, which comes from `fetch_licenses_from_github`. They fail on a machine with an empty cache and an exhausted unauthenticated rate limit (60 req/hr). Pre-existing; a `GITHUB_TOKEN` or a warm cache makes them pass.
 - **`serial_test` is used for tests that share global state.** Some tests modify static state (e.g., debug mode, GitHub token). Use `#[serial]` for these.
 - **The `progress` module and `LoadingIndicator`** write directly to stdout with ANSI escape codes. They're skipped in debug mode to avoid garbled output.
 - **Configuration validation is strict.** Duplicate licenses in restrictive/ignore lists, empty license strings, and licenses appearing in both lists are caught. See `src/config.rs`.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ feluda --no-local
 # Skip the vendored/unmanaged tree walk (faster on very large repos)
 feluda --no-vendor-scan
 
+# Skip the ClearlyDefined lookup for licenses Feluda could not resolve
+feluda --no-clearlydefined
+
 # Filter by OSI approval status
 feluda --osi approved        # Show only OSI approved licenses
 feluda --osi not-approved   # Show only non-OSI approved licenses
@@ -204,6 +207,21 @@ By default, Feluda checks local files first for license information before makin
 - **Java**: Fetches POM files from Maven Central to extract `<licenses>` metadata
 
 Use `--no-local` to skip local checks and force network-only license lookup.
+
+### ClearlyDefined Fallback
+
+Anything still unresolved after local files and registries is looked up in
+[ClearlyDefined](https://clearlydefined.io), whose curated definitions often name a license Feluda
+could not find on its own. One batched request covers a whole scan, answers are cached for a week,
+and a license that arrives this way is classified and gated exactly like any other. If the service
+is unreachable the dependency simply stays unresolved.
+
+Turn it off with `--no-clearlydefined`, or in `.feluda.toml`:
+
+```toml
+[clearlydefined]
+enabled = false
+```
 
 ### Beyond Manifests
 

--- a/docs/source/cli/cache.rst
+++ b/docs/source/cli/cache.rst
@@ -14,7 +14,22 @@ cache
 Overview
 --------
 
-Feluda caches GitHub license responses under ``.feluda/cache/github_licenses.json`` to stay under rate limits and speed up repeated scans.
+Feluda caches what it fetches, to stay under rate limits and to speed up repeated scans. Two files
+live in your user cache directory:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 20 45
+
+   * - File
+     - Expires after
+     - Holds
+   * - ``github_licenses.json``
+     - 30 days
+     - The GitHub license table, which drives restrictiveness classification
+   * - ``clearlydefined.json``
+     - 7 days
+     - Declared licenses ClearlyDefined answered with, keyed by package coordinate. Packages it had no answer for are cached too, so they are not asked about again on every run
 
 ----
 
@@ -27,7 +42,7 @@ Inspect cache statistics like size and freshness.
 
    feluda cache
 
-Feluda prints the cache location, the number of entries, and whether the cache is still valid.
+Feluda prints each cache's location, its number of entries, and whether it is still valid.
 
 **Output includes:**
 
@@ -47,7 +62,7 @@ Remove stale or corrupted cache data.
 
    feluda cache --clear
 
-Feluda deletes the cache file so the next scan starts fresh with remote data.
+Feluda deletes both cache files so the next scan starts fresh with remote data.
 
 **Options:**
 
@@ -58,7 +73,7 @@ Feluda deletes the cache file so the next scan starts fresh with remote data.
    * - Flag
      - Description
    * - ``--clear``
-     - Delete the cache file and start fresh
+     - Delete both cache files and start fresh
 
 ----
 
@@ -77,4 +92,7 @@ Cache Behavior
 
 **Cache location:**
 
-The cache is stored at ``.feluda/cache/github_licenses.json`` relative to the scanned project directory.
+Your user cache directory, which is ``~/Library/Caches/feluda`` on macOS,
+``$XDG_CACHE_HOME/feluda`` (or ``~/.cache/feluda``) on Linux, and ``%LOCALAPPDATA%\feluda`` on
+Windows. It is shared across projects, so a license resolved for one is already resolved for the
+next.

--- a/docs/source/cli/clearlydefined.rst
+++ b/docs/source/cli/clearlydefined.rst
@@ -1,0 +1,143 @@
+:description: How Feluda uses ClearlyDefined to resolve licenses no manifest, registry or license file could answer.
+
+.. _cli-clearlydefined:
+
+ClearlyDefined Fallback
+=======================
+
+.. rst-class:: lead
+
+   The last thing Feluda tries before reporting a license as unknown.
+
+----
+
+Overview
+--------
+
+Every resolution path ends somewhere. A manifest may state no license, a registry may not carry
+one, an installed wheel may ship no metadata, and the GitHub fallback only helps when Feluda knows
+which repository to ask about. Those dependencies report as ``Unknown``, which in a compliance
+report is the least useful answer there is.
+
+`ClearlyDefined <https://clearlydefined.io>`_ is a Linux Foundation project that curates exactly
+this gap: one definition per package coordinate, harvested by scancode, licensee and reuse, then
+corrected by human curation. Feluda asks it about anything it could not resolve on its own.
+
+The lookup runs on every scan source: a manifest scan, an ingested SBOM, and a cataloged
+filesystem all reach it, and so do ``feluda sbom`` and ``feluda generate``.
+
+.. code-block:: bash
+
+   feluda                                    # unknowns go to ClearlyDefined
+   feluda --no-clearlydefined                # ...or they do not
+
+----
+
+What Gets Asked
+---------------
+
+Only dependencies that are still unresolved after everything else, and only those whose ecosystem
+ClearlyDefined indexes. Every question is a package coordinate, so a whole scan's worth of unknowns
+is one request.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Ecosystem
+     - Coordinate
+   * - Rust
+     - ``crate/cratesio/-/serde/1.0.219``
+   * - Node
+     - ``npm/npmjs/-/lodash/4.17.21``, ``npm/npmjs/@babel/core/7.24.0``
+   * - Python
+     - ``pypi/pypi/-/requests/2.32.3``
+   * - Java
+     - ``maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.2``
+   * - Ruby
+     - ``gem/rubygems/-/rails/7.1.0``
+   * - .NET
+     - ``nuget/nuget/-/Newtonsoft.Json/13.0.3``
+   * - Go
+     - ``go/golang/github.com%2fgorilla/mux/v1.8.1``
+
+Nothing else is asked about. OS packages from a ``--filesystem`` scan are out because ClearlyDefined
+does not harvest rpm or apk, and a deb revision carries an architecture suffix Feluda does not
+record; CRAN and Conan are not supported by the service; and a vendored or own-source finding is a
+path rather than a package. A dependency pinned to a range rather than a version (``^1.2.3``) is
+also skipped, since a range is not something a definition can answer.
+
+----
+
+What Comes Back
+---------------
+
+The declared license, and only that. A definition also carries per-file scan results, but those
+include the licenses of test fixtures and vendored code inside the package, and reporting one of
+those as the package's license would be worse than reporting nothing. Definitions that declare
+``NOASSERTION``, ``NONE`` or ``OTHER`` are treated as no answer.
+
+A license that arrives this way is classified exactly like one from a manifest: restrictiveness,
+OSI status, compatibility and the CI gates all apply, so ``--fail-on-restrictive`` fails on a GPL
+dependency Feluda only learned about from ClearlyDefined.
+
+----
+
+Caching
+-------
+
+Answers are cached alongside the GitHub license table, in Feluda's cache directory, for seven days.
+That is shorter than the 30 days the GitHub table gets, because curations land continuously.
+
+Misses are cached too: a package ClearlyDefined has never heard of is not asked about again on
+every run. ``feluda cache --clear`` clears both caches.
+
+----
+
+Turning It Off
+--------------
+
+The lookup is on by default. It only runs for dependencies that already failed to resolve, and it
+is one batched request, so the cost is a fraction of the license fetching Feluda already does. It
+does mean package names and versions leave the machine, so projects that must not talk to a third
+party service turn it off:
+
+.. code-block:: bash
+
+   feluda --no-clearlydefined
+
+.. code-block:: toml
+
+   # .feluda.toml
+   [clearlydefined]
+   enabled = false
+
+.. code-block:: bash
+
+   export FELUDA_CLEARLYDEFINED_ENABLED=false
+
+``endpoint`` points the lookup somewhere else, for a mirror, a proxy, or a self-hosted instance:
+
+.. code-block:: toml
+
+   [clearlydefined]
+   endpoint = "https://clearlydefined.internal/definitions"
+
+----
+
+When It Fails
+-------------
+
+Silently, and by design. No network, a timeout, an error from the service: the dependency stays
+unresolved, which is where it already was. A scan never fails because ClearlyDefined was
+unreachable, and the wait is bounded, so a service that stops answering costs seconds rather than
+holding up a build.
+
+----
+
+Next Steps
+----------
+
+- :ref:`cli-scan` for the resolution order this sits at the end of
+- :ref:`configuration` for the rest of ``.feluda.toml``
+- :ref:`cli-cache` for managing what has been cached

--- a/docs/source/cli/scan.rst
+++ b/docs/source/cli/scan.rst
@@ -300,6 +300,32 @@ Feluda skips filesystem lookups and goes straight to remote sources, which is sl
 
 ----
 
+Resolve the Last Unknowns
+-------------------------
+
+Anything still unresolved after local files and registries goes to ClearlyDefined, whose curated
+definitions often name a license Feluda could not find on its own. It runs on every scan source and
+fails silently, so an unreachable service leaves the report exactly as it would have been.
+
+.. code-block:: bash
+
+   feluda --no-clearlydefined
+
+**Options:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Flag
+     - Description
+   * - ``--no-clearlydefined``
+     - Skip the ClearlyDefined lookup for unresolved licenses
+
+See :ref:`cli-clearlydefined` for what is asked, what comes back, and how to point it elsewhere.
+
+----
+
 Authenticate with GitHub
 ------------------------
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -197,6 +197,30 @@ Feluda re-evaluates every dependency against the updated matrix and flags incomp
 
 ----
 
+Control the ClearlyDefined fallback
+-----------------------------------
+
+Licenses Feluda cannot resolve on its own are looked up in ClearlyDefined. The lookup is on by
+default and only ever runs for dependencies that already failed to resolve.
+
+.. code-block:: toml
+
+   [clearlydefined]
+   enabled = true
+   endpoint = "https://api.clearlydefined.io/definitions"
+
+Set ``enabled = false`` when package names and versions must not leave the machine, or point
+``endpoint`` at a mirror, a proxy, or a self-hosted instance. Both have environment equivalents:
+
+.. code-block:: bash
+
+   export FELUDA_CLEARLYDEFINED_ENABLED=false
+   export FELUDA_CLEARLYDEFINED_ENDPOINT=https://clearlydefined.internal/definitions
+
+``--no-clearlydefined`` turns it off for a single run. See :ref:`cli-clearlydefined`.
+
+----
+
 Control environment overrides
 -----------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -163,6 +163,7 @@ Have a session to share? `Open a PR <https://github.com/anistark/feluda/edit/mai
    cli/index
    cli/scan
    cli/filesystem
+   cli/clearlydefined
    cli/watch
    cli/filter
    cli/cache

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -50,6 +50,9 @@ Use this table to double-check flag behavior before scripting.
    * - ``feluda --no-vendor-scan``
      - Skip the vendored/unmanaged dependency tree walk.
      - The walk covers the whole source tree; skip it on very large repos.
+   * - ``feluda --no-clearlydefined``
+     - Skip the ClearlyDefined lookup for unresolved licenses.
+     - The lookup is on by default; see :ref:`cli-clearlydefined`.
    * - ``feluda --github-token <token>``
      - Pass a GitHub token inline.
      - Overridden by ``GITHUB_TOKEN`` env var when both are present.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use crate::debug::{log, log_error, FeludaResult, LogLevel};
@@ -16,13 +16,18 @@ const CACHE_SUBDIR: &str = "feluda";
 const GITHUB_LICENSES_CACHE_FILE: &str = "github_licenses.json";
 const CACHE_TTL_SECS: u64 = 30 * 24 * 60 * 60; // 30 days
 
+/// ClearlyDefined answers are cached separately and expire sooner: the GitHub table is the SPDX
+/// license list, which barely moves, while ClearlyDefined definitions gain curations continuously.
+const CLEARLYDEFINED_CACHE_FILE: &str = "clearlydefined.json";
+const CLEARLYDEFINED_TTL_SECS: u64 = 7 * 24 * 60 * 60; // 7 days
+
 const CACHE_VERSION: u32 = 1;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
-struct CacheEntry {
+struct CacheEntry<T> {
     #[serde(default)]
     version: u32,
-    data: HashMap<String, License>,
+    data: HashMap<String, T>,
     timestamp: u64,
 }
 
@@ -49,13 +54,17 @@ fn github_cache_path() -> FeludaResult<PathBuf> {
     Ok(cache_dir_path()?.join(GITHUB_LICENSES_CACHE_FILE))
 }
 
-fn is_entry_fresh(timestamp: u64) -> bool {
+fn clearlydefined_cache_path() -> FeludaResult<PathBuf> {
+    Ok(cache_dir_path()?.join(CLEARLYDEFINED_CACHE_FILE))
+}
+
+fn is_entry_fresh_for(timestamp: u64, ttl_secs: u64) -> bool {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let age = now.saturating_sub(timestamp);
-    let is_fresh = age < CACHE_TTL_SECS;
+    let is_fresh = age < ttl_secs;
     log(
         LogLevel::Info,
         &format!("Cache age: {age} seconds (fresh: {is_fresh})"),
@@ -71,66 +80,73 @@ fn entry_age_secs(timestamp: u64) -> u64 {
     now.saturating_sub(timestamp)
 }
 
-pub fn load_github_licenses_from_cache() -> FeludaResult<Option<HashMap<String, License>>> {
-    let cache_path = github_cache_path()?;
-
-    if !cache_path.exists() {
-        log(LogLevel::Info, "No GitHub licenses cache found");
+/// Read a cache file, or `None` when it is absent, stale, from an older layout, or unreadable.
+///
+/// A cache that cannot be read is never an error: the caller's fallback is to fetch, which is what
+/// it would have done anyway.
+fn load_cache<T: serde::de::DeserializeOwned>(
+    path: &Path,
+    ttl_secs: u64,
+) -> FeludaResult<Option<HashMap<String, T>>> {
+    if !path.exists() {
+        log(
+            LogLevel::Info,
+            &format!("No cache found at {}", path.display()),
+        );
         return Ok(None);
     }
 
-    log(LogLevel::Info, "Loading GitHub licenses from cache");
-
-    match fs::read_to_string(&cache_path) {
-        Ok(content) => match serde_json::from_str::<CacheEntry>(&content) {
-            Ok(entry) => {
-                if entry.version != CACHE_VERSION {
-                    log(
-                        LogLevel::Info,
-                        &format!(
-                            "Cache version mismatch (got {}, expected {CACHE_VERSION}), will re-fetch",
-                            entry.version
-                        ),
-                    );
-                    return Ok(None);
-                }
-                if !is_entry_fresh(entry.timestamp) {
-                    log(
-                        LogLevel::Info,
-                        "GitHub licenses cache is stale, will re-fetch",
-                    );
-                    return Ok(None);
-                }
-                log(
-                    LogLevel::Info,
-                    &format!(
-                        "Successfully loaded {} licenses from cache",
-                        entry.data.len()
-                    ),
-                );
-                Ok(Some(entry.data))
-            }
-            Err(e) => {
-                log(
-                    LogLevel::Warn,
-                    &format!("Corrupt cache file, will re-fetch: {e}"),
-                );
-                Ok(None)
-            }
-        },
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
         Err(e) => {
             log(
                 LogLevel::Warn,
                 &format!("Failed to read cache file, will re-fetch: {e}"),
             );
-            Ok(None)
+            return Ok(None);
         }
+    };
+
+    let entry = match serde_json::from_str::<CacheEntry<T>>(&content) {
+        Ok(entry) => entry,
+        Err(e) => {
+            log(
+                LogLevel::Warn,
+                &format!("Corrupt cache file, will re-fetch: {e}"),
+            );
+            return Ok(None);
+        }
+    };
+
+    if entry.version != CACHE_VERSION {
+        log(
+            LogLevel::Info,
+            &format!(
+                "Cache version mismatch (got {}, expected {CACHE_VERSION}), will re-fetch",
+                entry.version
+            ),
+        );
+        return Ok(None);
     }
+
+    if !is_entry_fresh_for(entry.timestamp, ttl_secs) {
+        log(LogLevel::Info, "Cache is stale, will re-fetch");
+        return Ok(None);
+    }
+
+    log(
+        LogLevel::Info,
+        &format!(
+            "Loaded {} cached entries from {}",
+            entry.data.len(),
+            path.display()
+        ),
+    );
+    Ok(Some(entry.data))
 }
 
-pub fn save_github_licenses_to_cache(licenses: &HashMap<String, License>) -> FeludaResult<()> {
-    let cache_dir = ensure_cache_dir()?;
-    let cache_path = cache_dir.join(GITHUB_LICENSES_CACHE_FILE);
+fn save_cache<T: serde::Serialize>(path: &Path, data: &HashMap<String, T>) -> FeludaResult<()> {
+    ensure_cache_dir()?;
 
     let timestamp = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -139,7 +155,7 @@ pub fn save_github_licenses_to_cache(licenses: &HashMap<String, License>) -> Fel
 
     let json = match serde_json::to_string_pretty(&serde_json::json!({
         "version": CACHE_VERSION,
-        "data": licenses,
+        "data": data,
         "timestamp": timestamp,
     })) {
         Ok(json) => json,
@@ -149,27 +165,56 @@ pub fn save_github_licenses_to_cache(licenses: &HashMap<String, License>) -> Fel
         }
     };
 
-    fs::write(&cache_path, json).inspect_err(|e| log_error("Failed to write cache file", e))?;
+    fs::write(path, json).inspect_err(|e| log_error("Failed to write cache file", e))?;
 
     log(
         LogLevel::Info,
         &format!(
-            "Saved {} licenses to cache at {}",
-            licenses.len(),
-            cache_path.display()
+            "Saved {} entries to cache at {}",
+            data.len(),
+            path.display()
         ),
     );
 
     Ok(())
 }
 
-pub fn clear_github_licenses_cache() -> FeludaResult<()> {
-    let cache_path = github_cache_path()?;
+pub fn load_github_licenses_from_cache() -> FeludaResult<Option<HashMap<String, License>>> {
+    load_cache(&github_cache_path()?, CACHE_TTL_SECS)
+}
 
-    if cache_path.exists() {
-        fs::remove_file(&cache_path).inspect_err(|e| log_error("Failed to clear cache", e))?;
-        log(LogLevel::Info, "Cleared GitHub licenses cache");
-    } else {
+pub fn save_github_licenses_to_cache(licenses: &HashMap<String, License>) -> FeludaResult<()> {
+    save_cache(&github_cache_path()?, licenses)
+}
+
+/// Declared licenses ClearlyDefined answered with, keyed by coordinate.
+///
+/// The value is `None` for a coordinate ClearlyDefined has no answer for. Those are cached too, so
+/// a package it has never heard of is not asked about again on every run.
+pub fn load_clearlydefined_from_cache() -> FeludaResult<Option<HashMap<String, Option<String>>>> {
+    load_cache(&clearlydefined_cache_path()?, CLEARLYDEFINED_TTL_SECS)
+}
+
+pub fn save_clearlydefined_to_cache(
+    definitions: &HashMap<String, Option<String>>,
+) -> FeludaResult<()> {
+    save_cache(&clearlydefined_cache_path()?, definitions)
+}
+
+/// Clear every cache feluda keeps: the GitHub license table and the ClearlyDefined answers.
+pub fn clear_github_licenses_cache() -> FeludaResult<()> {
+    let mut cleared = false;
+    for path in [github_cache_path()?, clearlydefined_cache_path()?] {
+        if path.exists() {
+            fs::remove_file(&path).inspect_err(|e| log_error("Failed to clear cache", e))?;
+            log(
+                LogLevel::Info,
+                &format!("Cleared cache at {}", path.display()),
+            );
+            cleared = true;
+        }
+    }
+    if !cleared {
         log(LogLevel::Info, "No cache to clear");
     }
 
@@ -179,6 +224,8 @@ pub fn clear_github_licenses_cache() -> FeludaResult<()> {
 #[derive(Debug, serde::Serialize)]
 pub struct CacheStatus {
     pub exists: bool,
+    /// What this cache holds, for the status line.
+    pub label: &'static str,
     pub path: PathBuf,
     pub size_bytes: u64,
     pub is_fresh: bool,
@@ -217,7 +264,7 @@ impl CacheStatus {
 
     pub fn print_status(&self) {
         if !self.exists {
-            println!("\n📦 Cache Status: EMPTY");
+            println!("\n📦 {} Cache: EMPTY", self.label);
             println!("   No cache found at: {}", self.path.display());
             println!("   Cache will be created on next license analysis.\n");
             return;
@@ -229,11 +276,11 @@ impl CacheStatus {
             "✗ STALE"
         };
 
-        println!("\n📦 Cache Status: {health}");
+        println!("\n📦 {} Cache: {health}", self.label);
         println!("   Location: {}", self.path.display());
         println!("   Size: {}", Self::format_size(self.size_bytes));
         println!("   Age: {}", Self::format_age(self.age_secs));
-        println!("   Licenses cached: {}", self.license_count);
+        println!("   Entries cached: {}", self.license_count);
         println!();
     }
 }
@@ -241,8 +288,11 @@ impl CacheStatus {
 /// Visible for testing: parse a cache entry from JSON content and check freshness.
 #[cfg(test)]
 fn load_from_content(content: &str) -> Option<HashMap<String, License>> {
-    match serde_json::from_str::<CacheEntry>(content) {
-        Ok(entry) if entry.version == CACHE_VERSION && is_entry_fresh(entry.timestamp) => {
+    match serde_json::from_str::<CacheEntry<License>>(content) {
+        Ok(entry)
+            if entry.version == CACHE_VERSION
+                && is_entry_fresh_for(entry.timestamp, CACHE_TTL_SECS) =>
+        {
             Some(entry.data)
         }
         _ => None,
@@ -250,11 +300,28 @@ fn load_from_content(content: &str) -> Option<HashMap<String, License>> {
 }
 
 pub fn get_cache_status() -> FeludaResult<CacheStatus> {
-    let cache_path = github_cache_path()?;
+    status_of::<License>(github_cache_path()?, "GitHub Licenses", CACHE_TTL_SECS)
+}
 
+/// The ClearlyDefined answers cache, reported next to the GitHub one so `feluda cache` accounts
+/// for everything `--clear` would remove.
+pub fn get_clearlydefined_cache_status() -> FeludaResult<CacheStatus> {
+    status_of::<Option<String>>(
+        clearlydefined_cache_path()?,
+        "ClearlyDefined Answers",
+        CLEARLYDEFINED_TTL_SECS,
+    )
+}
+
+fn status_of<T: serde::de::DeserializeOwned>(
+    cache_path: PathBuf,
+    label: &'static str,
+    ttl_secs: u64,
+) -> FeludaResult<CacheStatus> {
     if !cache_path.exists() {
         return Ok(CacheStatus {
             exists: false,
+            label,
             path: cache_path,
             size_bytes: 0,
             is_fresh: false,
@@ -266,9 +333,9 @@ pub fn get_cache_status() -> FeludaResult<CacheStatus> {
     let size_bytes = fs::metadata(&cache_path)?.len();
 
     let (is_fresh, age_secs, license_count) = match fs::read_to_string(&cache_path) {
-        Ok(content) => match serde_json::from_str::<CacheEntry>(&content) {
+        Ok(content) => match serde_json::from_str::<CacheEntry<T>>(&content) {
             Ok(entry) => (
-                is_entry_fresh(entry.timestamp),
+                is_entry_fresh_for(entry.timestamp, ttl_secs),
                 entry_age_secs(entry.timestamp),
                 entry.data.len(),
             ),
@@ -279,6 +346,7 @@ pub fn get_cache_status() -> FeludaResult<CacheStatus> {
 
     Ok(CacheStatus {
         exists: true,
+        label,
         path: cache_path,
         size_bytes,
         is_fresh,
@@ -310,13 +378,13 @@ mod tests {
 
     #[test]
     fn fresh_entry_is_fresh() {
-        assert!(is_entry_fresh(now_secs()));
+        assert!(is_entry_fresh_for(now_secs(), CACHE_TTL_SECS));
     }
 
     #[test]
     fn stale_entry_is_not_fresh() {
         let old = now_secs() - CACHE_TTL_SECS - 1;
-        assert!(!is_entry_fresh(old));
+        assert!(!is_entry_fresh_for(old, CACHE_TTL_SECS));
     }
 
     #[test]
@@ -336,7 +404,7 @@ mod tests {
             timestamp: now_secs(),
         };
         let json = serde_json::to_string(&entry).unwrap();
-        let decoded: CacheEntry = serde_json::from_str(&json).unwrap();
+        let decoded: CacheEntry<License> = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.data.len(), 1);
         assert_eq!(decoded.data["MIT"].spdx_id, "MIT");
         assert_eq!(decoded.timestamp, entry.timestamp);

--- a/src/clearlydefined.rs
+++ b/src/clearlydefined.rs
@@ -1,0 +1,590 @@
+//! ClearlyDefined as a last-resort license source.
+//!
+//! Every resolution path feluda has ends somewhere. A manifest may state no license, a registry
+//! may not carry one, an installed wheel may ship no metadata, and the GitHub fallback only helps
+//! when the analyzer knows which repository to ask about. Those findings report as Unknown, which
+//! in a compliance report is the least useful answer available.
+//!
+//! [ClearlyDefined](https://clearlydefined.io) curates exactly this gap: one definition per package
+//! coordinate, harvested by scancode, licensee and reuse, then corrected by human curation. It is
+//! free, unauthenticated, and has a batch endpoint, so a whole scan's unknowns cost one request.
+//!
+//! This runs as a pass over finished findings rather than inside the analyzers. All three scan
+//! sources produce `Vec<LicenseInfo>` carrying an ecosystem, a name and a version, which is the
+//! coordinate ClearlyDefined keys on, so one pass covers manifests, ingested SBOMs and cataloged
+//! filesystems alike and nothing has to be threaded through eight language modules.
+//!
+//! Only `licensed.declared` is read. The same document carries per-file scan results under
+//! `facets.core.discovered`, but those include the licenses of test fixtures and vendored code
+//! inside the package, and reporting one of those as the package's license would be worse than
+//! reporting Unknown.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::cache;
+use crate::cli::with_spinner;
+use crate::config;
+use crate::debug::{log, LogLevel};
+use crate::licenses::{
+    fetch_licenses_from_github, get_osi_status, is_license_restrictive, is_unresolved_license,
+    LicenseInfo,
+};
+use crate::purl::Ecosystem;
+
+/// Trims the per-file scan results out of the response. They are not read, and they are the bulk
+/// of a definition: a batch of eight packages is 190KB with them and 12KB without.
+const NO_FILES: &str = "?expand=-files";
+
+/// Coordinates per request. The service accepts far more, but a bounded batch keeps one slow
+/// response from stalling a whole scan and keeps the retry cost small when one fails.
+const BATCH_SIZE: usize = 100;
+
+/// A successful batch answers in a second or two. The service does occasionally accept a request
+/// and never answer it, though, so the timeout is what bounds the cost of that rather than what
+/// a slow answer needs.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Attempts per batch, and the pause between them. The failure this retries is that silent hang,
+/// which a second attempt on a fresh connection usually does not hit.
+const ATTEMPTS: usize = 2;
+const RETRY_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Values `licensed.declared` uses to say it has no answer.
+const NO_ANSWER: &[&str] = &["NOASSERTION", "NONE", "OTHER", "UNKNOWN"];
+
+static DISABLED: OnceLock<bool> = OnceLock::new();
+
+/// Turn the lookup off for this process, from `--no-clearlydefined`.
+pub fn set_disabled(disabled: bool) {
+    let _ = DISABLED.set(disabled);
+}
+
+/// The endpoint to ask, or `None` when this run must not ask at all.
+fn endpoint() -> Option<String> {
+    if *DISABLED.get().unwrap_or(&false) {
+        log(LogLevel::Info, "ClearlyDefined disabled by flag");
+        return None;
+    }
+    let settings = config::load_config().ok()?.clearlydefined;
+    if !settings.enabled {
+        log(LogLevel::Info, "ClearlyDefined disabled by configuration");
+        return None;
+    }
+    Some(format!("{}{NO_FILES}", settings.endpoint))
+}
+
+/// Fill in licenses ClearlyDefined knows and feluda could not resolve.
+///
+/// Findings that already carry a license are untouched, and so are the ones whose ecosystem has no
+/// ClearlyDefined coordinate. A finding this does resolve is reclassified, since its restrictiveness
+/// and OSI status were decided against the Unknown it used to hold.
+///
+/// Returns the indices it filled in, which is what an ingested SBOM needs in order to write those
+/// licenses back into the enriched copy.
+///
+/// Never fails: a network error, a bad response or a coordinate the service has never seen all
+/// leave the finding exactly where it already was.
+pub fn resolve_unknown_licenses(findings: &mut [LicenseInfo], strict: bool) -> Vec<usize> {
+    let Some(endpoint) = endpoint() else {
+        return Vec::new();
+    };
+
+    let pending: Vec<(usize, String)> = findings
+        .iter()
+        .enumerate()
+        .filter(|(_, info)| is_unresolved_license(info.license.as_deref()))
+        .filter_map(|(index, info)| Some((index, coordinates(info)?)))
+        .collect();
+
+    if pending.is_empty() {
+        return Vec::new();
+    }
+
+    log(
+        LogLevel::Info,
+        &format!(
+            "Asking ClearlyDefined about {} unresolved package(s)",
+            pending.len()
+        ),
+    );
+
+    let definitions = with_spinner("🔍: ClearlyDefined", |indicator| {
+        let mut definitions = lookup(&pending, &endpoint);
+        definitions.retain(|_, license| license.is_some());
+        indicator.update_progress(&format!("{} resolved", definitions.len()));
+        definitions
+    });
+
+    if definitions.is_empty() {
+        return Vec::new();
+    }
+
+    let mut resolved = Vec::new();
+    let known_licenses = fetch_licenses_from_github().unwrap_or_default();
+    for (index, coordinate) in pending {
+        let Some(Some(license)) = definitions.get(&coordinate) else {
+            continue;
+        };
+        let info = &mut findings[index];
+        log(
+            LogLevel::Info,
+            &format!("ClearlyDefined resolved {coordinate} as {license}"),
+        );
+        info.license = Some(license.clone());
+        info.is_restrictive = is_license_restrictive(&info.license, &known_licenses, strict);
+        info.osi_status = get_osi_status(license);
+        resolved.push(index);
+    }
+
+    resolved
+}
+
+/// Answer every coordinate, from the cache where possible and the API for the rest.
+///
+/// Misses are cached as well as hits: a package ClearlyDefined has never heard of should not cost
+/// a request on every subsequent run.
+fn lookup(pending: &[(usize, String)], endpoint: &str) -> HashMap<String, Option<String>> {
+    let cached = cache::load_clearlydefined_from_cache()
+        .unwrap_or_default()
+        .unwrap_or_default();
+
+    let mut answers: HashMap<String, Option<String>> = HashMap::new();
+    let mut missing: HashSet<String> = HashSet::new();
+    for (_, coordinate) in pending {
+        match cached.get(coordinate) {
+            Some(license) => {
+                answers.insert(coordinate.clone(), license.clone());
+            }
+            None => {
+                missing.insert(coordinate.clone());
+            }
+        }
+    }
+    let missing: Vec<String> = missing.into_iter().collect();
+
+    if missing.is_empty() {
+        return answers;
+    }
+
+    let mut fetched = 0;
+    for batch in missing.chunks(BATCH_SIZE) {
+        let Some(definitions) = fetch_batch(batch, endpoint) else {
+            // Stop rather than work through the remaining batches: whatever is wrong with the
+            // service or the network is not specific to this batch, and this is a fallback that
+            // must not turn a scan into a wait.
+            log(
+                LogLevel::Warn,
+                "Giving up on ClearlyDefined for this run; unresolved licenses stay unresolved",
+            );
+            break;
+        };
+        fetched += batch.len();
+        for coordinate in batch {
+            let license = definitions.get(coordinate).and_then(declared_license);
+            answers.insert(coordinate.clone(), license);
+        }
+    }
+
+    if fetched > 0 {
+        let mut to_cache = cached;
+        to_cache.extend(answers.clone());
+        if let Err(e) = cache::save_clearlydefined_to_cache(&to_cache) {
+            log(
+                LogLevel::Warn,
+                &format!("Failed to save ClearlyDefined cache: {e}"),
+            );
+        }
+    }
+
+    answers
+}
+
+/// One batch, retried once on a fresh connection.
+///
+/// The service intermittently accepts a request and never answers it, and a pooled connection it
+/// has done that on tends to do it again, so each attempt gets its own client rather than sharing
+/// one across the batch.
+fn fetch_batch(batch: &[String], endpoint: &str) -> Option<HashMap<String, Definition>> {
+    (0..ATTEMPTS).find_map(|attempt| {
+        if attempt > 0 {
+            std::thread::sleep(RETRY_BACKOFF);
+        }
+        fetch_batch_once(batch, endpoint)
+    })
+}
+
+fn fetch_batch_once(batch: &[String], endpoint: &str) -> Option<HashMap<String, Definition>> {
+    // HTTP/1.1 by negotiation, not by preference: the service accepts an HTTP/2 POST and then
+    // never answers it at all.
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(concat!("feluda/", env!("CARGO_PKG_VERSION")))
+        .timeout(REQUEST_TIMEOUT)
+        .http1_only()
+        .build()
+        .inspect_err(|e| {
+            log(
+                LogLevel::Warn,
+                &format!("Could not build ClearlyDefined client: {e}"),
+            )
+        })
+        .ok()?;
+
+    let response = client
+        .post(endpoint)
+        .json(&batch)
+        .send()
+        .inspect_err(|e| {
+            log(
+                LogLevel::Warn,
+                &format!("ClearlyDefined request failed: {e}"),
+            )
+        })
+        .ok()?;
+
+    if !response.status().is_success() {
+        log(
+            LogLevel::Warn,
+            &format!("ClearlyDefined returned {}", response.status()),
+        );
+        return None;
+    }
+
+    response
+        .json::<HashMap<String, Definition>>()
+        .inspect_err(|e| {
+            log(
+                LogLevel::Warn,
+                &format!("Could not read ClearlyDefined response: {e}"),
+            )
+        })
+        .ok()
+}
+
+#[derive(Debug, Deserialize)]
+struct Definition {
+    #[serde(default)]
+    licensed: Option<Licensed>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Licensed {
+    #[serde(default)]
+    declared: Option<String>,
+}
+
+/// The declared license of a definition, or `None` when it declares nothing usable.
+fn declared_license(definition: &Definition) -> Option<String> {
+    let declared = definition.licensed.as_ref()?.declared.as_ref()?.trim();
+    if declared.is_empty() || NO_ANSWER.contains(&declared.to_ascii_uppercase().as_str()) {
+        return None;
+    }
+    Some(declared.to_string())
+}
+
+/// The ClearlyDefined coordinate for a finding: `type/provider/namespace/name/revision`.
+///
+/// `None` for anything the service does not index. OS packages are out because a deb revision
+/// carries an architecture suffix feluda does not record and rpm and apk are not harvested at all;
+/// CRAN and Conan are not supported; and a `generic` finding is a path, not a package.
+fn coordinates(info: &LicenseInfo) -> Option<String> {
+    let (kind, provider) = match info.ecosystem {
+        Ecosystem::Cargo => ("crate", "cratesio"),
+        Ecosystem::Npm => ("npm", "npmjs"),
+        Ecosystem::Pypi => ("pypi", "pypi"),
+        Ecosystem::Maven => ("maven", "mavencentral"),
+        Ecosystem::Gem => ("gem", "rubygems"),
+        Ecosystem::Nuget => ("nuget", "nuget"),
+        Ecosystem::Golang => ("go", "golang"),
+        Ecosystem::Cran
+        | Ecosystem::Conan
+        | Ecosystem::Deb
+        | Ecosystem::Rpm
+        | Ecosystem::Apk
+        | Ecosystem::Generic => return None,
+    };
+
+    let (namespace, name) = split_name(info.ecosystem, info.name.trim())?;
+    let revision = revision(info.ecosystem, info.version.trim())?;
+    Some(format!("{kind}/{provider}/{namespace}/{name}/{revision}"))
+}
+
+/// Split a display name into ClearlyDefined's namespace and name, `-` when there is no namespace.
+fn split_name(ecosystem: Ecosystem, name: &str) -> Option<(String, String)> {
+    if name.is_empty() {
+        return None;
+    }
+    // Maven's namespace is the group id, and an artifact reported without one cannot be located:
+    // asking with an empty namespace would be asking about a different package.
+    if ecosystem == Ecosystem::Maven && !name.contains(':') {
+        return None;
+    }
+
+    let split = match ecosystem {
+        // An npm scope is the namespace and keeps its `@`.
+        Ecosystem::Npm => name
+            .strip_prefix('@')
+            .and_then(|rest| rest.split_once('/'))
+            .map(|(scope, package)| (format!("@{scope}"), package.to_string())),
+        Ecosystem::Maven => name
+            .split_once(':')
+            .map(|(group, artifact)| (group.to_string(), artifact.to_string())),
+        // A Go module path is a namespace of path segments plus a final name, and the separators
+        // inside the namespace are escaped so the coordinate keeps its five parts.
+        Ecosystem::Golang => name
+            .rsplit_once('/')
+            .map(|(namespace, package)| (namespace.replace('/', "%2f"), package.to_string())),
+        _ => None,
+    };
+
+    let (namespace, name) = split.unwrap_or_else(|| ("-".to_string(), name.to_string()));
+    if name.is_empty() || namespace.is_empty() {
+        return None;
+    }
+    // A name carrying a separator would push the coordinate out of shape.
+    if name.contains('/') {
+        return None;
+    }
+    Some((namespace, name))
+}
+
+/// The revision to ask about, or `None` when the version is not a single concrete release.
+///
+/// Manifests hold ranges (`^1.2.3`, `>=2,<3`) as often as they hold versions, and a range is not
+/// something ClearlyDefined can answer. Go module versions carry their `v` prefix.
+fn revision(ecosystem: Ecosystem, version: &str) -> Option<String> {
+    if version.is_empty() || version.len() > 64 {
+        return None;
+    }
+    if version
+        .chars()
+        .any(|c| c.is_whitespace() || "^~*|,<>=()[]{}/\\".contains(c))
+    {
+        return None;
+    }
+    if !version
+        .strip_prefix('v')
+        .unwrap_or(version)
+        .starts_with(|c: char| c.is_ascii_digit())
+    {
+        return None;
+    }
+    if ecosystem == Ecosystem::Golang && !version.starts_with('v') {
+        return Some(format!("v{version}"));
+    }
+    Some(version.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::licenses::{LicenseCompatibility, OsiStatus};
+
+    fn finding(ecosystem: Ecosystem, name: &str, version: &str) -> LicenseInfo {
+        LicenseInfo {
+            name: name.to_string(),
+            version: version.to_string(),
+            license: None,
+            is_restrictive: false,
+            compatibility: LicenseCompatibility::Unknown,
+            osi_status: OsiStatus::Unknown,
+            ecosystem,
+            sub_project: None,
+        }
+    }
+
+    #[test]
+    fn test_coordinates_per_ecosystem() {
+        let cases = [
+            (
+                finding(Ecosystem::Cargo, "serde", "1.0.219"),
+                "crate/cratesio/-/serde/1.0.219",
+            ),
+            (
+                finding(Ecosystem::Npm, "lodash", "4.17.21"),
+                "npm/npmjs/-/lodash/4.17.21",
+            ),
+            (
+                finding(Ecosystem::Npm, "@babel/core", "7.24.0"),
+                "npm/npmjs/@babel/core/7.24.0",
+            ),
+            (
+                finding(Ecosystem::Pypi, "requests", "2.32.3"),
+                "pypi/pypi/-/requests/2.32.3",
+            ),
+            (
+                finding(
+                    Ecosystem::Maven,
+                    "com.fasterxml.jackson.core:jackson-databind",
+                    "2.15.2",
+                ),
+                "maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.2",
+            ),
+            (
+                finding(Ecosystem::Gem, "rails", "7.1.0"),
+                "gem/rubygems/-/rails/7.1.0",
+            ),
+            (
+                finding(Ecosystem::Nuget, "Newtonsoft.Json", "13.0.3"),
+                "nuget/nuget/-/Newtonsoft.Json/13.0.3",
+            ),
+            (
+                finding(Ecosystem::Golang, "github.com/gorilla/mux", "v1.8.1"),
+                "go/golang/github.com%2fgorilla/mux/v1.8.1",
+            ),
+        ];
+
+        for (info, expected) in cases {
+            assert_eq!(coordinates(&info).as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn test_go_version_gains_its_v_prefix() {
+        let info = finding(Ecosystem::Golang, "github.com/gorilla/mux", "1.8.1");
+        assert_eq!(
+            coordinates(&info).as_deref(),
+            Some("go/golang/github.com%2fgorilla/mux/v1.8.1")
+        );
+    }
+
+    #[test]
+    fn test_unindexed_ecosystems_have_no_coordinate() {
+        for ecosystem in [
+            Ecosystem::Deb,
+            Ecosystem::Rpm,
+            Ecosystem::Apk,
+            Ecosystem::Cran,
+            Ecosystem::Conan,
+            Ecosystem::Generic,
+        ] {
+            let info = finding(ecosystem, "debian/libssl3", "3.0.15");
+            assert_eq!(coordinates(&info), None, "{ecosystem:?}");
+        }
+    }
+
+    #[test]
+    fn test_version_ranges_are_not_asked_about() {
+        for version in ["^1.2.3", ">=2.0", "1.0 - 2.0", "*", "latest", "", "~4.17"] {
+            let info = finding(Ecosystem::Npm, "lodash", version);
+            assert_eq!(coordinates(&info), None, "{version}");
+        }
+    }
+
+    #[test]
+    fn test_empty_name_has_no_coordinate() {
+        assert_eq!(coordinates(&finding(Ecosystem::Npm, "  ", "1.0.0")), None);
+    }
+
+    #[test]
+    fn test_maven_artifact_without_a_group_is_not_asked_about() {
+        let info = finding(Ecosystem::Maven, "jackson-databind", "2.15.2");
+        assert_eq!(coordinates(&info), None);
+    }
+
+    fn definition(declared: Option<&str>) -> Definition {
+        Definition {
+            licensed: Some(Licensed {
+                declared: declared.map(str::to_string),
+            }),
+        }
+    }
+
+    #[test]
+    fn test_declared_license_is_read() {
+        assert_eq!(
+            declared_license(&definition(Some("MIT OR Apache-2.0"))).as_deref(),
+            Some("MIT OR Apache-2.0")
+        );
+    }
+
+    #[test]
+    fn test_non_answers_are_not_licenses() {
+        for declared in ["NOASSERTION", "NONE", "OTHER", "unknown", "  ", ""] {
+            assert_eq!(
+                declared_license(&definition(Some(declared))),
+                None,
+                "{declared}"
+            );
+        }
+        assert_eq!(declared_license(&definition(None)), None);
+        assert_eq!(declared_license(&Definition { licensed: None }), None);
+    }
+
+    #[test]
+    fn test_response_parses_into_definitions() {
+        let body = r#"{
+            "npm/npmjs/-/lodash/4.17.21": {
+                "described": {"releaseDate": "2021-02-20"},
+                "licensed": {"declared": "CC0-1.0 AND MIT"},
+                "scores": {"effective": 87}
+            },
+            "npm/npmjs/-/nope/1.0.0": {
+                "licensed": {"toolScore": {"total": 0}},
+                "scores": {"effective": 0}
+            }
+        }"#;
+        let definitions: HashMap<String, Definition> = serde_json::from_str(body).unwrap();
+        assert_eq!(
+            definitions
+                .get("npm/npmjs/-/lodash/4.17.21")
+                .and_then(declared_license)
+                .as_deref(),
+            Some("CC0-1.0 AND MIT")
+        );
+        assert_eq!(
+            definitions
+                .get("npm/npmjs/-/nope/1.0.0")
+                .and_then(declared_license),
+            None
+        );
+    }
+}
+
+/// Live checks against the real service, skipped by default: `cargo test -- --ignored clearlydefined`.
+///
+/// They are the only way to catch the service changing its coordinate scheme or its response shape
+/// out from under the parsing above, which no fixture can tell us.
+#[cfg(test)]
+mod live {
+    use super::*;
+
+    #[test]
+    #[ignore = "needs network"]
+    fn the_batch_endpoint_answers_every_coordinate_shape() {
+        let batch: Vec<String> = [
+            "crate/cratesio/-/serde/1.0.219",
+            "npm/npmjs/@babel/core/7.24.0",
+            "pypi/pypi/-/requests/2.32.3",
+            "maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.2",
+            "gem/rubygems/-/rails/7.1.0",
+            "nuget/nuget/-/Newtonsoft.Json/13.0.3",
+            "go/golang/github.com%2fgorilla/mux/v1.8.1",
+        ]
+        .iter()
+        .map(|c| c.to_string())
+        .collect();
+
+        let definitions = fetch_batch(&batch, &endpoint().expect("enabled by default"))
+            .expect("batch request failed");
+        for coordinate in &batch {
+            let declared = definitions
+                .get(coordinate)
+                .and_then(declared_license)
+                .unwrap_or_else(|| panic!("no declared license for {coordinate}"));
+            assert!(!declared.is_empty());
+        }
+    }
+
+    #[test]
+    #[ignore = "needs network"]
+    fn an_unknown_coordinate_answers_with_no_license() {
+        let batch = vec!["npm/npmjs/-/feluda-not-a-real-package/9.9.9".to_string()];
+        let definitions = fetch_batch(&batch, &endpoint().expect("enabled by default"))
+            .expect("batch request failed");
+        assert_eq!(definitions.get(&batch[0]).and_then(declared_license), None);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -301,6 +301,10 @@ pub struct Cli {
     /// Skip the vendored/unmanaged dependency tree walk (faster on large repos)
     #[arg(long, help_heading = HEADING_DETECTION)]
     pub no_vendor_scan: bool,
+
+    /// Skip the ClearlyDefined lookup for licenses Feluda could not resolve
+    #[arg(long, help_heading = HEADING_DETECTION)]
+    pub no_clearlydefined: bool,
 }
 
 impl Cli {
@@ -832,6 +836,7 @@ mod tests {
             strict: false,
             no_local: false,
             no_vendor_scan: false,
+            no_clearlydefined: false,
         };
 
         assert_eq!(cli.path, "./");
@@ -879,6 +884,7 @@ mod tests {
             strict: false,
             no_local: false,
             no_vendor_scan: false,
+            no_clearlydefined: false,
         };
 
         let cmd = cli.get_command_args();
@@ -933,6 +939,7 @@ mod tests {
             strict: false,
             no_local: false,
             no_vendor_scan: false,
+            no_clearlydefined: false,
         };
 
         let cmd = cli.get_command_args();

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,8 @@ pub struct FeludaConfig {
     #[serde(default)]
     pub dependencies: DependencyConfig,
     #[serde(default)]
+    pub clearlydefined: ClearlyDefinedConfig,
+    #[serde(default)]
     pub strict: bool,
 }
 
@@ -94,6 +96,44 @@ impl FeludaConfig {
 /// - EPL-2.0
 ///
 /// This can be overridden via `.feluda.toml` or environment variables.
+/// Whether unresolved licenses may be looked up in ClearlyDefined.
+///
+/// On by default: the lookup only runs for findings that already failed to resolve, and one
+/// batched request answers a whole scan. Projects that must not talk to a third party service turn
+/// it off here, or per run with `--no-clearlydefined`.
+///
+/// ```toml
+/// [clearlydefined]
+/// enabled = false
+/// ```
+///
+/// `endpoint` points the lookup somewhere else: an air-gapped mirror, a proxy, or a self-hosted
+/// instance. It is the definitions endpoint, without a query string.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ClearlyDefinedConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_clearlydefined_endpoint")]
+    pub endpoint: String,
+}
+
+impl Default for ClearlyDefinedConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            endpoint: default_clearlydefined_endpoint(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_clearlydefined_endpoint() -> String {
+    "https://api.clearlydefined.io/definitions".to_string()
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct LicenseConfig {
     #[serde(default = "default_restrictive_licenses")]
@@ -807,6 +847,7 @@ restrictive = ["TOML-LICENSE-1", "TOML-LICENSE-2"]"#,
     #[test]
     fn test_config_serialization() {
         let config = FeludaConfig {
+            clearlydefined: ClearlyDefinedConfig::default(),
             strict: false,
             licenses: LicenseConfig {
                 restrictive: vec!["TEST-1.0".to_string(), "TEST-2.0".to_string()],
@@ -1160,6 +1201,7 @@ match_all = ["Cal.com, Inc."]
     #[test]
     fn test_feluda_config_validation_success() {
         let config = FeludaConfig {
+            clearlydefined: ClearlyDefinedConfig::default(),
             strict: false,
             licenses: LicenseConfig {
                 restrictive: vec!["MIT".to_string(), "GPL-3.0".to_string()],
@@ -1177,6 +1219,7 @@ match_all = ["Cal.com, Inc."]
     #[test]
     fn test_feluda_config_validation_license_failure() {
         let config = FeludaConfig {
+            clearlydefined: ClearlyDefinedConfig::default(),
             strict: false,
             licenses: LicenseConfig {
                 restrictive: vec!["".to_string()], // Invalid empty license
@@ -1199,6 +1242,7 @@ match_all = ["Cal.com, Inc."]
     #[test]
     fn test_feluda_config_validation_dependency_failure() {
         let config = FeludaConfig {
+            clearlydefined: ClearlyDefinedConfig::default(),
             strict: false,
             licenses: LicenseConfig {
                 restrictive: vec!["MIT".to_string()],
@@ -1631,6 +1675,7 @@ reason = "All versions ignored"
     #[test]
     fn test_feluda_config_with_dependency_ignore() {
         let config = FeludaConfig {
+            clearlydefined: ClearlyDefinedConfig::default(),
             strict: false,
             licenses: LicenseConfig {
                 restrictive: vec!["GPL-3.0".to_string()],

--- a/src/filesystem/mod.rs
+++ b/src/filesystem/mod.rs
@@ -160,6 +160,7 @@ pub fn scan_filesystem(root: &Path, strict: bool) -> FeludaResult<Vec<LicenseInf
 
     artifacts::resolve_missing_licenses(&mut findings);
     classify_findings(&mut findings, strict);
+    crate::clearlydefined::resolve_unknown_licenses(&mut findings, strict);
     Ok(findings)
 }
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -1518,6 +1518,8 @@ pub fn handle_generate_command(
         }
     };
 
+    crate::clearlydefined::resolve_unknown_licenses(&mut analyzed_data, false);
+
     log_debug("Analyzed dependencies for generate command", &analyzed_data);
 
     // Update each dependency with compatibility information if project license is known

--- a/src/init.rs
+++ b/src/init.rs
@@ -106,6 +106,13 @@ ignore = []
 # match_all = ["ACME CONFIDENTIAL", "Internal Use Only"]
 # restrictive = true   # omit to classify `id` the usual way
 
+# Licenses feluda cannot resolve on its own are looked up in ClearlyDefined, whose
+# curated definitions often name one. On by default; turn it off if package names
+# and versions must not leave this machine, or point it at your own instance.
+# [clearlydefined]
+# enabled = false
+# endpoint = "https://clearlydefined.internal/definitions"
+
 [dependencies]
 # Maximum depth for transitive dependency resolution (1–100).
 max_depth = 10

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cache;
+mod clearlydefined;
 mod cli;
 mod config;
 mod debug;
@@ -101,6 +102,8 @@ fn run() -> FeludaResult<()> {
 
     // Set GitHub API token for authenticated requests
     set_github_token(args.github_token.clone());
+
+    clearlydefined::set_disabled(args.no_clearlydefined);
 
     // Handle repository cloning if --repo is provided
     let (analysis_path, _temp_dir) = match &args.repo.clone() {
@@ -450,6 +453,11 @@ fn analyze_dependencies(config: &CheckConfig) -> FeludaResult<(Vec<LicenseInfo>,
         analyzed_data.extend(vendored_findings);
     }
 
+    // Last resort for anything still unresolved. The other two sources run this themselves, since
+    // an ingested SBOM has to be enriched with the result and a cataloged filesystem is finished
+    // by the time it returns.
+    clearlydefined::resolve_unknown_licenses(&mut analyzed_data, config.strict);
+
     Ok((analyzed_data, project_license))
 }
 
@@ -728,8 +736,8 @@ fn handle_cache_command(clear: bool) -> FeludaResult<()> {
         cache::clear_github_licenses_cache()?;
         println!("✓ Cache cleared successfully\n");
     } else {
-        let status = cache::get_cache_status()?;
-        status.print_status();
+        cache::get_cache_status()?.print_status();
+        cache::get_clearlydefined_cache_status()?.print_status();
     }
     Ok(())
 }

--- a/src/sbom/ingest.rs
+++ b/src/sbom/ingest.rs
@@ -72,6 +72,10 @@ pub fn ingest_sbom(
 
     resolve_missing_licenses(&mut components, &mut origins);
     classify_findings(&mut components, strict);
+    // Before the enriched document is written, so what it states is everything feluda resolved.
+    for index in crate::clearlydefined::resolve_unknown_licenses(&mut components, strict) {
+        origins[index].resolved = true;
+    }
 
     if let Some(output_path) = enriched_output {
         write_enriched(&document, format, &components, &origins, output_path)?;

--- a/src/sbom/mod.rs
+++ b/src/sbom/mod.rs
@@ -57,8 +57,12 @@ pub fn handle_sbom_command(
 
     let analyzed_data = match &filesystem {
         Some(root) => scan_filesystem(std::path::Path::new(root), false)?,
-        None => parse_root(&path, None, false, false)
-            .map_err(|e| FeludaError::Parser(format!("Failed to parse dependencies: {e}")))?,
+        None => {
+            let mut analyzed_data = parse_root(&path, None, false, false)
+                .map_err(|e| FeludaError::Parser(format!("Failed to parse dependencies: {e}")))?;
+            crate::clearlydefined::resolve_unknown_licenses(&mut analyzed_data, false);
+            analyzed_data
+        }
     };
 
     log(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -445,6 +445,7 @@ mod tests {
             strict: false,
             no_local: false,
             no_vendor_scan: false,
+            no_clearlydefined: false,
         };
 
         let result = clone_repository(&args, temp_dir.path());
@@ -505,6 +506,7 @@ mod tests {
             strict: false,
             no_local: false,
             no_vendor_scan: false,
+            no_clearlydefined: false,
         };
 
         // Enable debug mode for this test
@@ -564,6 +566,7 @@ mod tests {
             strict: false,
             no_local: false,
             no_vendor_scan: false,
+            no_clearlydefined: false,
         };
 
         let result = clone_repository(&args, temp_dir.path());

--- a/tests/clearlydefined_integration.rs
+++ b/tests/clearlydefined_integration.rs
@@ -1,0 +1,245 @@
+//! Integration tests for the ClearlyDefined fallback.
+//!
+//! The lookup is pointed at a stub server on localhost through `FELUDA_CLEARLYDEFINED_ENDPOINT`,
+//! so the whole path runs for real (coordinates out, declared licenses back, findings reclassified)
+//! without the suite depending on a third party service being up. Findings arrive through
+//! `--sbom-input`, which is the shortest way to hand feluda packages it cannot resolve.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Command, Output};
+use std::sync::mpsc;
+use std::thread;
+
+use serde_json::Value;
+
+/// Two components with no license, one of which ClearlyDefined will answer for.
+const SBOM: &str = r#"{
+  "spdxVersion": "SPDX-2.3",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "fixture",
+  "documentNamespace": "https://example.com/fixture",
+  "creationInfo": {"created": "2026-01-01T00:00:00Z", "creators": ["Tool: fixture"]},
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-1",
+      "name": "mystery",
+      "versionInfo": "1.2.3",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [{
+        "referenceCategory": "PACKAGE-MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:cargo/mystery@1.2.3"
+      }]
+    },
+    {
+      "SPDXID": "SPDXRef-2",
+      "name": "copyleft-mystery",
+      "versionInfo": "4.5.6",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "externalRefs": [{
+        "referenceCategory": "PACKAGE-MANAGER",
+        "referenceType": "purl",
+        "referenceLocator": "pkg:cargo/copyleft-mystery@4.5.6"
+      }]
+    }
+  ]
+}"#;
+
+const RESPONSE: &str = r#"{
+  "crate/cratesio/-/mystery/1.2.3": {
+    "described": {"releaseDate": "2026-01-01"},
+    "licensed": {"declared": "Apache-2.0"},
+    "scores": {"effective": 80}
+  },
+  "crate/cratesio/-/copyleft-mystery/4.5.6": {
+    "licensed": {"declared": "GPL-3.0"},
+    "scores": {"effective": 70}
+  }
+}"#;
+
+/// A stub of the definitions endpoint, serving one canned response and reporting back the request
+/// body it was sent so the coordinates can be asserted on.
+struct Stub {
+    endpoint: String,
+    requests: mpsc::Receiver<String>,
+}
+
+impl Stub {
+    fn start(body: &'static str) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind stub server");
+        let endpoint = format!(
+            "http://{}/definitions",
+            listener.local_addr().expect("stub server has no address")
+        );
+        let (sender, requests) = mpsc::channel();
+
+        thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                let Some(request) = serve(stream, body) else {
+                    continue;
+                };
+                if sender.send(request).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self { endpoint, requests }
+    }
+
+    fn request_body(&self) -> String {
+        self.requests
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("stub server received no request")
+    }
+}
+
+/// Read one HTTP request and answer it. Returns the request body.
+fn serve(stream: TcpStream, body: &str) -> Option<String> {
+    let mut reader = BufReader::new(stream.try_clone().ok()?);
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None;
+        }
+        if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = value.trim().parse().ok()?;
+        }
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+    }
+
+    let mut request = vec![0u8; content_length];
+    reader.read_exact(&mut request).ok()?;
+
+    let mut stream = stream;
+    write!(
+        stream,
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    )
+    .ok()?;
+    stream.flush().ok()?;
+
+    String::from_utf8(request).ok()
+}
+
+/// `home` isolates the run's cache directory. Answers are cached, so without this a second run of
+/// the suite would be served from the developer's own cache and never reach the stub.
+fn feluda(
+    home: &std::path::Path,
+    sbom: &str,
+    endpoint: Option<&str>,
+    extra_args: &[&str],
+) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_feluda"));
+    command
+        .args(["--sbom-input", sbom, "--json"])
+        .args(extra_args)
+        .env("HOME", home)
+        .env("XDG_CACHE_HOME", home.join("cache"));
+    match endpoint {
+        Some(endpoint) => command.env("FELUDA_CLEARLYDEFINED_ENDPOINT", endpoint),
+        None => command.env("FELUDA_CLEARLYDEFINED_ENABLED", "false"),
+    };
+    command.output().expect("failed to run feluda binary")
+}
+
+fn report(output: &Output) -> Vec<Value> {
+    assert!(
+        output.status.success(),
+        "feluda exited with {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("feluda emitted invalid JSON: {e}\n{stdout}"))
+}
+
+fn entry<'a>(entries: &'a [Value], name: &str) -> &'a Value {
+    entries
+        .iter()
+        .find(|entry| entry["name"] == name)
+        .unwrap_or_else(|| panic!("no entry named {name:?} in report: {entries:#?}"))
+}
+
+fn write_sbom(dir: &std::path::Path) -> String {
+    let path = dir.join("fixture.spdx.json");
+    std::fs::write(&path, SBOM).expect("failed to write fixture SBOM");
+    path.to_string_lossy().to_string()
+}
+
+#[test]
+fn unresolved_licenses_are_filled_in_and_reclassified() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let sbom = write_sbom(temp.path());
+    let stub = Stub::start(RESPONSE);
+
+    let output = feluda(temp.path(), &sbom, Some(&stub.endpoint), &[]);
+    let entries = report(&output);
+
+    let permissive = entry(&entries, "mystery");
+    assert_eq!(permissive["license"], "Apache-2.0");
+    assert_eq!(permissive["is_restrictive"], false);
+    assert_eq!(permissive["osi_status"], "Approved");
+
+    // The point of reclassifying: a license that arrives from ClearlyDefined has to reach the gate
+    // the same way one from a manifest does.
+    let restrictive = entry(&entries, "copyleft-mystery");
+    assert_eq!(restrictive["license"], "GPL-3.0");
+    assert_eq!(restrictive["is_restrictive"], true);
+}
+
+#[test]
+fn packages_are_asked_about_by_coordinate() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let sbom = write_sbom(temp.path());
+    let stub = Stub::start(RESPONSE);
+
+    feluda(temp.path(), &sbom, Some(&stub.endpoint), &[]);
+
+    let requested: Vec<String> =
+        serde_json::from_str(&stub.request_body()).expect("stub received invalid JSON");
+    assert!(requested.contains(&"crate/cratesio/-/mystery/1.2.3".to_string()));
+    assert!(requested.contains(&"crate/cratesio/-/copyleft-mystery/4.5.6".to_string()));
+}
+
+#[test]
+fn a_resolved_license_fails_the_restrictive_gate() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let sbom = write_sbom(temp.path());
+    let stub = Stub::start(RESPONSE);
+
+    let output = feluda(
+        temp.path(),
+        &sbom,
+        Some(&stub.endpoint),
+        &["--fail-on-restrictive"],
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn the_lookup_can_be_turned_off() {
+    let temp = tempfile::tempdir().expect("failed to create temp dir");
+    let sbom = write_sbom(temp.path());
+
+    for entries in [
+        report(&feluda(temp.path(), &sbom, None, &[])),
+        report(&feluda(temp.path(), &sbom, None, &["--no-clearlydefined"])),
+    ] {
+        assert!(entry(&entries, "mystery")["license"].is_null());
+        assert!(entry(&entries, "copyleft-mystery")["license"].is_null());
+    }
+}

--- a/tests/filesystem_scan_integration.rs
+++ b/tests/filesystem_scan_integration.rs
@@ -64,9 +64,13 @@ const DPKG_STATUS: &str = "Package: libssl3\n\
     Version: 1.0\n\
     \n";
 
+/// Every test drives the binary with the ClearlyDefined fallback off: the fixtures are built so
+/// license resolution succeeds locally, and a network lookup would make the suite depend on a
+/// third party service being up.
 fn feluda(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_feluda"))
         .args(args)
+        .env("FELUDA_CLEARLYDEFINED_ENABLED", "false")
         .output()
         .expect("failed to run feluda binary")
 }

--- a/tests/parser_integration.rs
+++ b/tests/parser_integration.rs
@@ -19,7 +19,10 @@ const MIT_TEXT: &str = "MIT License\n\nCopyright (c) 2026 Fixture\n\nPermission 
 
 fn run_feluda(dir: &Path, args: &[&str], envs: &[(&str, &str)]) -> Output {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_feluda"));
-    cmd.current_dir(dir)
+    // The fixtures resolve locally; the ClearlyDefined fallback would make the suite depend on a
+    // third party service being up.
+    cmd.env("FELUDA_CLEARLYDEFINED_ENABLED", "false")
+        .current_dir(dir)
         .arg("--path")
         .arg(dir.to_str().unwrap())
         .args(args);

--- a/tests/sbom_ingest_integration.rs
+++ b/tests/sbom_ingest_integration.rs
@@ -139,9 +139,13 @@ const CDXGEN_CYCLONEDX: &str = r#"{
   ]
 }"#;
 
+/// Every test drives the binary with the ClearlyDefined fallback off: the fixtures are built so
+/// license resolution succeeds locally, and a network lookup would make the suite depend on a
+/// third party service being up.
 fn feluda(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_feluda"))
         .args(args)
+        .env("FELUDA_CLEARLYDEFINED_ENABLED", "false")
         .output()
         .expect("failed to run feluda binary")
 }
@@ -150,6 +154,7 @@ fn feluda(args: &[&str]) -> Output {
 fn feluda_with_stdin(args: &[&str], input: &str) -> Output {
     let mut child = Command::new(env!("CARGO_BIN_EXE_feluda"))
         .args(args)
+        .env("FELUDA_CLEARLYDEFINED_ENABLED", "false")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
A finding reports as Unknown when every path feluda has runs out: the manifest states nothing, the registry carries nothing, the installed wheel shipped no metadata, and the GitHub fallback has no repository to ask about. In a compliance report that is the least useful answer there is, so `src/clearlydefined.rs` asks ClearlyDefined before giving up, whose curated definitions usually name one.

It runs as a pass over finished findings rather than per analyzer wiring. All three sources produce a `Vec<LicenseInfo>` carrying an ecosystem, a name and a version, which is a ClearlyDefined coordinate in a different spelling, so `resolve_unknown_licenses()` covers manifests, `--sbom-input` and `--filesystem` at once, and `sbom` and `generate` with them. The identity work from #248 is what makes that cheap: the mapping is per ecosystem name normalization and nothing else. cargo, npm, pypi, maven, gem, nuget and golang are asked about. deb, rpm and apk are not indexed, cran and conan are not supported, and a `generic` finding is a path rather than a package.

Only `licensed.declared` is read. The same document carries per file scan results, but those cover test fixtures and vendored code inside the package, and reporting one of those as the package's license would be worse than reporting nothing. Anything resolved is reclassified against the same restrictive list and OSI table as any other license, so a GPL dependency feluda only learned about here still fails `--fail-on-restrictive`.

On by default, since it only fires for findings that already failed and one batched request covers a whole scan. `--no-clearlydefined` turns it off for a run, `[clearlydefined] enabled = false` for a project, and `endpoint` points it at a mirror or a self hosted instance. Answers are cached for 7 days, misses included, so a package it has never heard of is not asked about again on every run. `feluda cache` now reports both cache files and `--clear` removes both.

Two things about the service shaped the client, both reproducible with curl rather than anything reqwest does. It accepts an HTTP/2 POST and then never answers it, so the client is `http1_only()`. It also intermittently hangs on HTTP/1.1, about one request in three during testing, so there is a 10 second timeout, one retry on a fresh connection, and the run gives up once a batch has failed twice. Failure is silent: the finding stays where it already was and no scan waits on it.

`tests/clearlydefined_integration.rs` drives the binary against a stub server on localhost through `FELUDA_CLEARLYDEFINED_ENDPOINT`, so the happy path is covered offline, with the live checks behind `#[ignore]`. The three existing integration harnesses now set `FELUDA_CLEARLYDEFINED_ENABLED=false` so the suite never depends on a third party being up. Docs get a `cli/clearlydefined` page, and the cache page loses a claim it carried before this: the cache lives in the user cache directory, not `.feluda/cache/`.