### PR TITLE
docs: sync the docs version from Cargo.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,9 +344,11 @@ test: description          # Adding/fixing tests
 
 ## Versioning
 
-- Version source of truth: `Cargo.toml` (`version = "X.Y.Z"`).
+- Version source of truth: `Cargo.toml` (`version = "X.Y.Z"`). `Cargo.lock` picks it up on the next build.
+- A version bump must also update `release = 'vX.Y.Z'` in `docs/source/conf.py`. It drives the version pill in the docs sidebar, and `just publish` does not touch it.
 - Follow [Semantic Versioning](https://semver.org/).
 - `just publish` handles: build → test → package → crates.io publish → git tag → push tag.
+- Full release steps: `docs/source/contributing/releasing.rst`.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,7 +345,7 @@ test: description          # Adding/fixing tests
 ## Versioning
 
 - Version source of truth: `Cargo.toml` (`version = "X.Y.Z"`). `Cargo.lock` picks it up on the next build.
-- A version bump must also update `release = 'vX.Y.Z'` in `docs/source/conf.py`. It drives the version pill in the docs sidebar, and `just publish` does not touch it.
+- A version bump must also update `release = 'vX.Y.Z'` in `docs/source/conf.py`. It drives the version pill in the docs sidebar, and `just publish` does not touch it. Run `just sync-version` after editing `Cargo.toml` to copy the version across.
 - Follow [Semantic Versioning](https://semver.org/).
 - `just publish` handles: build → test → package → crates.io publish → git tag → push tag.
 - Full release steps: `docs/source/contributing/releasing.rst`.

--- a/README.md
+++ b/README.md
@@ -790,6 +790,8 @@ Feluda allows you to customize which licenses are considered restrictive and whi
 ### Default Restrictive Licenses
 
 By default, Feluda considers the following licenses as restrictive:
+- GPL-1.0
+- GPL-2.0
 - GPL-3.0
 - AGPL-3.0
 - LGPL-3.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = 'Feluda'
 copyright = '2025, The Feluda Maintainers'
 author = 'The Feluda Maintainers'
-release = 'v1.15.0'
+release = 'v1.16.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -23,7 +23,7 @@ Feluda ships with a conservative restrictive list so risky licenses stand out on
    * - Default category
      - Contents
    * - Restrictive licenses
-     - ``GPL-3.0``, ``AGPL-3.0``, ``LGPL-3.0``, ``MPL-2.0``, ``SEE LICENSE IN LICENSE``, ``CC-BY-SA-4.0``, ``EPL-2.0``
+     - ``GPL-1.0``, ``GPL-2.0``, ``GPL-3.0``, ``AGPL-3.0``, ``LGPL-3.0``, ``MPL-2.0``, ``SEE LICENSE IN LICENSE``, ``CC-BY-SA-4.0``, ``EPL-2.0``
    * - Cache location
      - ``.feluda/cache/github_licenses.json`` refreshed automatically every 30 days
    * - Compatibility data

--- a/docs/source/contributing/releasing.rst
+++ b/docs/source/contributing/releasing.rst
@@ -32,9 +32,29 @@ We'll be using justfile for next steps, so setup `just <https://github.com/casey
 Release Process
 ---------------
 
-The release process is split into two steps:
+The release process is split into three steps:
 
-Step 1: Publish to crates.io and push tag
+Step 1: Bump the version
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The version lives in two places, and both have to be updated before publishing:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - File
+     - Field
+   * - ``Cargo.toml``
+     - ``version = "X.Y.Z"`` (source of truth; ``Cargo.lock`` updates on the next build)
+   * - ``docs/source/conf.py``
+     - ``release = 'vX.Y.Z'``
+
+``conf.py`` feeds the version pill next to the Feluda logo in the docs sidebar, so if it is missed the documentation site keeps advertising the previous release.
+
+Commit both together, for example ``chore: release vX.Y.Z``.
+
+Step 2: Publish to crates.io and push tag
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: sh
@@ -52,7 +72,7 @@ This will:
 4. Publish to crates.io
 5. Create and push the version tag to GitHub (with optional pre-release suffix)
 
-Step 2: Create GitHub release manually
+Step 3: Create GitHub release manually
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After the tag is pushed, create the GitHub release manually via the GitHub UI:

--- a/docs/source/contributing/releasing.rst
+++ b/docs/source/contributing/releasing.rst
@@ -52,6 +52,12 @@ The version lives in two places, and both have to be updated before publishing:
 
 ``conf.py`` feeds the version pill next to the Feluda logo in the docs sidebar, so if it is missed the documentation site keeps advertising the previous release.
 
+Bump ``Cargo.toml`` by hand, then let just copy it across:
+
+.. code-block:: sh
+
+   just sync-version
+
 Commit both together, for example ``chore: release vX.Y.Z``.
 
 Step 2: Publish to crates.io and push tag

--- a/justfile
+++ b/justfile
@@ -65,6 +65,14 @@ debian-release:
     dpkg-buildpackage -us -uc
     dput ppa:your-ppa-name ../{{CRATE_NAME}}_{{VERSION}}_source.changes
 
+# Sync the docs version in conf.py from Cargo.toml
+sync-version:
+    @echo "🔄 Syncing docs version to v{{VERSION}}..."
+    sed -i.bak "s/^release = .*/release = 'v{{VERSION}}'/" "{{DOCS_SOURCE}}/conf.py"
+    @rm -f "{{DOCS_SOURCE}}/conf.py.bak"
+    @grep -n "^release = " "{{DOCS_SOURCE}}/conf.py"
+    @echo "✅ Docs version synced. Commit the change before publishing."
+
 # Publish the crate to crates.io
 publish RELEASE_TYPE="": build test-release package
     cargo publish

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,8 @@ impl FeludaConfig {
 /// Configuration for license-related settings
 ///
 /// By default, the following licenses are considered restrictive:
+/// - GPL-1.0
+/// - GPL-2.0
 /// - GPL-3.0
 /// - AGPL-3.0
 /// - LGPL-3.0
@@ -499,7 +501,14 @@ fn default_max_depth() -> u32 {
 
 /// Returns the default list of restrictive licenses
 fn default_restrictive_licenses() -> Vec<String> {
+    // Matching is a substring test, so an entry covers every id that contains it: "GPL-2.0" also
+    // catches "GPL-2.0-only", "GPL-2.0-or-later", "LGPL-2.0" and "AGPL-2.0". This list is the
+    // fallback used whenever the GitHub license registry is unreachable, so the GPL family has to
+    // be complete here: a missing version means a copyleft dependency is reported as permissive on
+    // any offline or rate limited run.
     let licenses = vec![
+        "GPL-1.0",
+        "GPL-2.0",
         "GPL-3.0",
         "AGPL-3.0",
         "LGPL-3.0",
@@ -602,7 +611,7 @@ mod tests {
             std::env::set_current_dir(dir.path()).unwrap();
 
             let config = load_config().unwrap();
-            assert_eq!(config.licenses.restrictive.len(), 7);
+            assert_eq!(config.licenses.restrictive.len(), 9);
             assert!(config.licenses.restrictive.contains(&"GPL-3.0".to_string()));
         });
     }
@@ -682,7 +691,7 @@ restrictive = ["TOML-1.0", "TOML-2.0"]"#,
     #[test]
     fn test_license_config_default() {
         let config = LicenseConfig::default();
-        assert_eq!(config.restrictive.len(), 7);
+        assert_eq!(config.restrictive.len(), 9);
         assert!(config.restrictive.contains(&"GPL-3.0".to_string()));
         assert!(config.restrictive.contains(&"AGPL-3.0".to_string()));
         assert!(config.restrictive.contains(&"LGPL-3.0".to_string()));
@@ -697,13 +706,15 @@ restrictive = ["TOML-1.0", "TOML-2.0"]"#,
     #[test]
     fn test_feluda_config_default() {
         let config = FeludaConfig::default();
-        assert_eq!(config.licenses.restrictive.len(), 7);
+        assert_eq!(config.licenses.restrictive.len(), 9);
     }
 
     #[test]
     fn test_default_restrictive_licenses() {
         let licenses = default_restrictive_licenses();
-        assert_eq!(licenses.len(), 7);
+        assert_eq!(licenses.len(), 9);
+        assert!(licenses.contains(&"GPL-1.0".to_string()));
+        assert!(licenses.contains(&"GPL-2.0".to_string()));
         assert!(licenses.contains(&"GPL-3.0".to_string()));
         assert!(licenses.contains(&"AGPL-3.0".to_string()));
         assert!(licenses.contains(&"LGPL-3.0".to_string()));
@@ -721,7 +732,7 @@ restrictive = ["TOML-1.0", "TOML-2.0"]"#,
 
             let config = load_config().unwrap();
 
-            assert_eq!(config.licenses.restrictive.len(), 7);
+            assert_eq!(config.licenses.restrictive.len(), 9);
             assert!(config.licenses.restrictive.contains(&"GPL-3.0".to_string()));
         });
     }
@@ -756,7 +767,7 @@ some_field = "value"
 
             let config = load_config().unwrap();
 
-            assert_eq!(config.licenses.restrictive.len(), 7);
+            assert_eq!(config.licenses.restrictive.len(), 9);
         });
     }
 
@@ -970,7 +981,7 @@ restrictive = [
 
                 let config = load_config().unwrap();
 
-                assert_eq!(config.licenses.restrictive.len(), 7);
+                assert_eq!(config.licenses.restrictive.len(), 9);
                 assert!(config.licenses.restrictive.contains(&"GPL-3.0".to_string()));
                 assert!(!config
                     .licenses

--- a/src/init.rs
+++ b/src/init.rs
@@ -88,6 +88,8 @@ fn generate_feluda_toml(project_license: Option<&str>) -> String {
 # AI coding tools (Cursor, Copilot, Windsurf) can silently pull in GPL/AGPL deps —
 # keeping this list tight catches those before they reach production.
 restrictive = [
+    "GPL-1.0",
+    "GPL-2.0",
     "GPL-3.0",
     "AGPL-3.0",
     "LGPL-3.0",


### PR DESCRIPTION
**The version pill in the docs sidebar was a release behind.** It reads `release` from `docs/source/conf.py`, which is bumped by hand, and the v1.16.0 release only bumped `Cargo.toml`.
- New `just sync-version` reads the version from `Cargo.toml` (via the existing `VERSION` variable, itself derived from `cargo pkgid`) and rewrites the `release` line, so the version is typed in one place only
- `docs/source/conf.py` bumped to match the current release
- The releasing guide gains a "Bump the version" step naming both files and the command, and the Versioning section of `AGENTS.md` points at it

Deliberately not wired into `just publish`: that recipe tags and pushes, so editing `conf.py` partway through would leave a change the tag doesn't contain. The order is bump, sync, commit, then publish.

Testing: ran `just sync-version` on an already-synced tree (no-op) and against a stale `release` line. Pre-commit ran fmt, clippy and the full 703-test suite on both commits.
