### PR TITLE
docs: document the container and filesystem sources, and feluda init

### DIFF
--- a/docs/source/cli/containers.rst
+++ b/docs/source/cli/containers.rst
@@ -1,0 +1,147 @@
+:description: Scan a container image for license compliance with Feluda.
+
+.. _cli-containers:
+
+Scan a Container Image
+======================
+
+.. rst-class:: lead
+
+   Three routes from an image to a license verdict, and why none of them is ``--image``.
+
+----
+
+Overview
+--------
+
+Feluda has no flag that takes an image reference. What it has is two scan sources that between
+them cover the case completely: :ref:`sbom-ingest` reads an inventory another tool produced, and
+:ref:`cli-filesystem` catalogues a tree directly. An image becomes one or the other first.
+
+Which route to take depends on what you already run, not on what you are scanning.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Route
+     - Use when
+     - What it costs
+   * - Pipe syft
+     - syft is already in the pipeline
+     - Another tool to install, and its cataloguing rather than Feluda's
+   * - Export the image
+     - Docker is available locally
+     - Disk for the extracted tree
+   * - Copy with skopeo
+     - CI has no Docker daemon
+     - Another tool to install, but no daemon and no credentials in Feluda
+
+----
+
+Pipe an Existing Cataloguer
+---------------------------
+
+syft, Trivy and cdxgen all catalogue images well. What they do not do is resolve, classify or gate:
+they report whichever license string the package metadata carried and stop. That is where Feluda
+starts.
+
+.. code-block:: bash
+
+   syft nginx:latest -o spdx-json | feluda --sbom-input - --fail-on-restrictive
+
+``-`` reads from stdin, so nothing touches disk. The same path takes a vendor's SBOM, which is
+often the only inventory you get for an image you did not build. See :ref:`sbom-ingest`.
+
+----
+
+Export and Scan the Tree
+------------------------
+
+``docker export`` flattens a container to a tarball, which Feluda scans with no other tool in the
+pipeline:
+
+.. code-block:: bash
+
+   docker create --name tmp nginx:latest
+   docker export tmp | tar -x -C rootfs
+   docker rm tmp
+   feluda --filesystem rootfs --fail-on-restrictive
+
+This reads apk, dpkg and rpm databases plus installed Python and Node artifacts, and for the OS
+packages it needs no network at all, since their licenses are already in the tree. It feeds the
+document writers too:
+
+.. code-block:: bash
+
+   feluda sbom spdx --filesystem rootfs --output nginx.spdx.json
+
+The resulting document describes what the image ships rather than what a source tree declares.
+
+----
+
+Without a Docker Daemon
+-----------------------
+
+CI runners often have no daemon. ``skopeo`` pulls straight from a registry into an OCI layout, and
+handles the credentials itself:
+
+.. code-block:: bash
+
+   skopeo copy docker://nginx:latest dir:./rootfs-layers
+   # then extract the layers in manifest order and scan the result
+   feluda --filesystem rootfs
+
+``crane export`` does the same job in one step if you prefer it. Either way Feluda never sees a
+registry credential.
+
+----
+
+Why There Is No ``--image``
+---------------------------
+
+Pulling an image by reference means Feluda would speak the OCI distribution API itself, and almost
+none of that work is about licenses:
+
+- **Reference parsing.** ``nginx:latest`` means ``docker.io/library/nginx:latest``, and
+  ``localhost:5000/app:v1`` has a colon that is a port and a colon that is a tag.
+- **Authentication.** The bearer token exchange, then ``~/.docker/config.json``, then credential
+  helpers invoked as subprocesses, then ECR, Artifact Registry and ACR each doing it their own way,
+  then rate limit handling for anonymous pulls.
+- **Manifests.** A tag usually resolves to an index, so a platform has to be chosen, and buildx
+  attestation manifests in that index have to be skipped rather than scanned as layers.
+- **Blobs.** Digest verification, decompression, CDN redirects where the auth header must be
+  dropped, retries and caching.
+
+Registry authentication is the largest ongoing support surface in every scanner in this category,
+and the three routes above already cover the case. Feluda would rather own license resolution well
+than own credential handling at all.
+
+What is worth building is the half below that line: reading a ``docker save`` tarball or an OCI
+layout directly, which is layer squashing and whiteout handling over catalogers that already exist,
+with no network and no credentials. That is proposed in `issue #265
+<https://github.com/anistark/feluda/issues/265>`_ and would collapse the export step above into
+one command. A registry client stays unfiled until someone asks for it by name, with a workflow
+where materialising the image locally is genuinely not an option.
+
+----
+
+Known Gaps
+----------
+
+For images these routes do not fully cover, catalogue with syft and ingest the result:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Gap
+     - Tracking
+   * - rpm ndb and Berkeley DB backends, so SUSE, openSUSE and CentOS 7 era images
+     - `#263 <https://github.com/anistark/feluda/issues/263>`_
+   * - Go build info, so distroless Go images report nothing
+     - `#264 <https://github.com/anistark/feluda/issues/264>`_
+   * - Installed Ruby gemspecs and jar manifests
+     - `#254 <https://github.com/anistark/feluda/issues/254>`_
+   * - ``docker save`` tarballs and OCI layouts as a direct source
+     - `#265 <https://github.com/anistark/feluda/issues/265>`_

--- a/docs/source/cli/filesystem.rst
+++ b/docs/source/cli/filesystem.rst
@@ -28,6 +28,9 @@ That makes a shipped container analysable with nothing else in the pipeline: no 
 and no image handling. For the OS packages there is no network either, since their licenses are
 already in the tree.
 
+For the routes from an image reference to a tree, and why there is no ``--image`` flag, see
+:ref:`cli-containers`.
+
 ----
 
 What Is Covered
@@ -265,8 +268,8 @@ Not Yet Covered
 ---------------
 
 Installed Ruby gemspecs, jars and Go build info are not catalogued yet, and neither are the two
-older rpm backends above. Until they are, pipe syft's output through :ref:`sbom-ingest` for those
-cases:
+older rpm backends above. :ref:`cli-containers` tracks each gap against its issue. Until they are
+closed, pipe syft's output through :ref:`sbom-ingest` for those cases:
 
 .. code-block:: bash
 

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -43,8 +43,12 @@ Command Overview
      - Description
    * - ``feluda``
      - Scan dependencies and detect licenses
+   * - ``feluda init``
+     - Write ``.feluda.toml`` and a pre-commit hook for the project
    * - ``feluda --filesystem``
-     - Catalogue the OS packages installed under a root filesystem
+     - Catalogue the OS packages and installed artifacts under a root filesystem
+   * - ``feluda --sbom-input``
+     - Scan an SPDX or CycloneDX document another tool produced
    * - ``feluda watch``
      - Continuously re-scan when dependency files change
    * - ``feluda cache``

--- a/docs/source/cli/init.rst
+++ b/docs/source/cli/init.rst
@@ -1,0 +1,91 @@
+:description: Set up Feluda in a project with a generated config file and pre-commit hook.
+
+.. _cli-init:
+
+Initialise a Project
+====================
+
+.. rst-class:: lead
+
+   One command to get a policy file and a pre-commit gate in place.
+
+----
+
+Overview
+--------
+
+Feluda needs no configuration to run, so ``init`` is a convenience rather than a
+prerequisite. What it does is write the two files most projects end up wanting anyway:
+a ``.feluda.toml`` carrying the license policy, and a ``.pre-commit-config.yaml`` that
+runs the scan before a commit lands.
+
+.. code-block:: bash
+
+   feluda init
+
+It inspects the project first, so what it writes is not generic. Manifests in the tree
+decide which ecosystems are reported as detected, and the project's own license is
+detected and recorded in the generated config, so compatibility checking works on the
+next run without you naming it.
+
+----
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Flag
+     - Behaviour
+   * - ``-p``, ``--path <PATH>``
+     - Project directory to initialise. Defaults to ``./``.
+   * - ``--force``
+     - Overwrite ``.feluda.toml`` and add the hook without prompting. Use it in scripts,
+       where there is nobody to answer the questions.
+   * - ``--no-pre-commit``
+     - Write only ``.feluda.toml``. Use it when the repository manages hooks another way.
+
+Without ``--force`` the command asks before touching anything that already exists, so
+running it twice is safe.
+
+----
+
+What Gets Written
+-----------------
+
+``.feluda.toml`` holds the restrictive list, an empty ``ignore`` list to fill in, and a
+``max_depth`` for transitive resolution. The custom license and ClearlyDefined blocks
+are written commented out, as a pointer to what can be configured rather than as active
+policy. See :ref:`configuration` for the full schema.
+
+``.pre-commit-config.yaml`` gets a local hook that runs ``feluda --fail-on-restrictive``
+on every commit, with ``always_run`` set, since a dependency can change without a
+manifest appearing in the staged diff. If the file already exists, the hook is appended
+to it rather than replacing what is there, and a hook Feluda has already added is not
+added twice.
+
+The generated hook calls ``feluda`` from ``PATH``, so contributors need it installed.
+See :ref:`install`.
+
+.. code-block:: bash
+
+   feluda init
+   pre-commit install
+
+The second command is what actually activates the hook, and ``init`` prints it as a
+next step rather than running it for you.
+
+----
+
+Editing the Result
+------------------
+
+The generated policy is a starting point, not a recommendation to keep as is. The
+restrictive list is deliberately conservative, and ``MPL-2.0`` or ``EPL-2.0`` in
+particular are file level copyleft that many projects are happy to ship. Take them out
+if that is your position, rather than working around the report later.
+
+To gate on compatibility with your own license as well as on restrictive licenses, add
+``--fail-on-incompatible`` to the hook's ``args``.

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -93,6 +93,46 @@ some other way, and that is exactly the code nobody audits.
 
 ----
 
+Scan what you ship, not what you declare
+----------------------------------------
+
+A manifest describes a source tree. What reaches production is an image: a base
+distribution nobody wrote a manifest for, plus whatever the build installed on top of
+it. Feluda reads that directly, with no cataloguing tool in the pipeline.
+
+.. code-block:: console
+
+   $ feluda --filesystem ./rootfs --fail-on-restrictive
+
+.. grid:: 1 1 3 3
+   :gutter: 3
+
+   .. grid-item-card:: :iconify:`lucide:hard-drive` Installed packages, not declared ones
+      :class-card: glassmorphic
+      :link: cli/filesystem
+      :link-type: doc
+
+      apk, dpkg and rpm databases, read where the system keeps them, plus the Python
+      distributions and Node packages installed beside them. For OS packages there is no
+      network call at all, since the licenses are already in the tree.
+
+   .. grid-item-card:: :iconify:`simple-icons:docker` Container images
+      :class-card: glassmorphic
+      :link: cli/containers
+      :link-type: doc
+
+      Export an image and scan the tree, or pipe syft's output straight in. Both routes
+      end in the same verdict, and both feed the SBOM writers.
+
+   .. grid-item-card:: :iconify:`lucide:fingerprint` One identity per package
+      :class-card: glassmorphic
+
+      Every finding carries an ecosystem and a PURL, down to the distribution a package
+      came from: ``pkg:deb/debian/libssl3@3.0.15-1``. A library the OS installed and the
+      same library in ``site-packages`` is reported once, not twice.
+
+----
+
 Know which licenses actually matter
 -----------------------------------
 
@@ -317,3 +357,11 @@ Start investigating
       :link-type: doc
 
       From install to first verdict, with the flags worth knowing on day one.
+
+   .. grid-item-card:: :iconify:`lucide:settings` Set up the project
+      :class-card: glassmorphic
+      :link: cli/init
+      :link-type: doc
+
+      ``feluda init`` writes a policy file with your license already detected, and a
+      pre-commit hook that fails the commit rather than the release.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -161,8 +161,10 @@ Have a session to share? `Open a PR <https://github.com/anistark/feluda/edit/mai
    :hidden:
 
    cli/index
+   cli/init
    cli/scan
    cli/filesystem
+   cli/containers
    cli/clearlydefined
    cli/watch
    cli/filter

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -44,6 +44,15 @@ Use this table to double-check flag behavior before scripting.
    * - ``feluda --fail-on-restrictive`` / ``feluda --fail-on-incompatible``
      - Exit non-zero when risky findings exist.
      - Ideal for CI as in :ref:`integrations`.
+   * - ``feluda --filesystem <dir>``
+     - Catalogue what is installed under a tree instead of scanning manifests.
+     - Reads apk, dpkg and rpm databases plus installed Python and Node artifacts. Cannot be combined with ``--repo`` or ``--sbom-input``. See :ref:`cli-filesystem`.
+   * - ``feluda --sbom-input <file>``
+     - Scan an SPDX or CycloneDX document instead of a project tree.
+     - ``-`` reads stdin, so ``syft image -o spdx-json | feluda --sbom-input -`` works. See :ref:`sbom-ingest`.
+   * - ``feluda --sbom-enriched <file>``
+     - Write the ingested SBOM back out with the licenses Feluda resolved.
+     - Requires ``--sbom-input``.
    * - ``feluda --no-local``
      - Skip local manifests and fetch data remotely.
      - Helpful when manifests are incomplete or stale.
@@ -59,6 +68,9 @@ Use this table to double-check flag behavior before scripting.
    * - ``feluda watch``
      - Re-scan continuously when dependency files change.
      - Report-only; accepts ``--path`` and ``--debounce``. See :ref:`cli-watch`.
+   * - ``feluda init``
+     - Write ``.feluda.toml`` and a pre-commit hook.
+     - Accepts ``--path``, ``--force``, ``--no-pre-commit``. See :ref:`cli-init`.
    * - ``feluda cache`` / ``feluda cache --clear``
      - Inspect or delete the GitHub license cache.
      - Default cache path: ``.feluda/cache/github_licenses.json``.
@@ -85,7 +97,7 @@ Use this table to double-check flag behavior before scripting.
      - Accepts ``--path``, ``--language``, ``--project-license``.
    * - ``feluda sbom [spdx|cyclonedx]``
      - Generate SBOM in SPDX 2.3 or CycloneDX v1.5 format.
-     - Omit format to generate both; use ``--output`` to save.
+     - Omit format to generate both; use ``--output`` to save, or ``--filesystem`` to describe an installed tree.
    * - ``feluda sbom validate <file>``
      - Validate an SBOM file against its specification.
      - Supports ``--json`` for machine-readable output.

--- a/docs/source/sbom/index.rst
+++ b/docs/source/sbom/index.rst
@@ -24,6 +24,9 @@ A filesystem can be catalogued directly too, with no other tool involved:
 ``feluda sbom spdx --filesystem ./rootfs`` describes what an artifact ships rather than what its
 source declares. See :ref:`cli-filesystem`.
 
+For container images specifically, :ref:`cli-containers` covers the routes from an image reference
+to either of those two sources.
+
 Generate Both Formats
 ---------------------
 


### PR DESCRIPTION
New `cli/containers` page answers it with the three routes that exist today, syft piped into `--sbom-input`, `docker export` into `--filesystem`, and `skopeo` or `crane` for runners with no daemon, then says why there is no `--image` flag and what the registry client would actually cost. Its Known Gaps table maps each gap to the issue tracking it.

`feluda init` turned out to be undocumented entirely, mentioned only in passing inside the Claude Code integration page despite writing two files into the user's repo, so it gets a page of its own.

- New `cli/containers` page, cross-linked from `cli/filesystem` and the SBOM index
- New `cli/init` page covering `--path`, `--force` and `--no-pre-commit`, what lands in `.feluda.toml` and `.pre-commit-config.yaml`, and that `pre-commit install` is what activates the hook
- Features page gains a section on scanning the shipped artifact rather than the declared one, plus a card for `feluda init`
- Reference flag table gains `--filesystem`, `--sbom-input`, `--sbom-enriched` and `feluda init`, which were all missing
- CLI index lists `feluda init` and `feluda --sbom-input`, and its `--filesystem` line now mentions installed artifacts rather than OS packages alone

For devs:
- Both new pages registered in the `index.rst` toctrees
- `doc8 source --ignore D001` and `sphinx-build -W` both clean

Refs #247